### PR TITLE
celery and celery beat integration and docker init helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ governanceplatform/static/
 theme/
 
 static/npm_components
+volumes/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 SHELL := /bin/bash
 
+VERSION?=$(shell git describe --exact-match --tags 2>/dev/null || echo "latest" )
+IMAGE?=local/nisinp
+
+.PHONY: image
+
 # target: all - Default target. Does nothing.
 all:
 	@echo "Hello $(LOGNAME), nothing to do by default."
@@ -42,3 +47,6 @@ update:
 clean:
 	find . -type f -name "*.py[co]" -delete
 	find . -type d -name "__pycache__" -delete
+
+image:
+	docker build -f docker/Dockerfile --build-arg APP_VERSION=$(shell git describe --tags) -t $(IMAGE):$(VERSION) .

--- a/celery_beat.py
+++ b/celery_beat.py
@@ -1,0 +1,35 @@
+import os
+from celery import Celery
+from celery.schedules import crontab
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'governanceplatform.settings')
+
+app = Celery('governanceplatform')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+app.conf.beat_schedule = {
+    "email_reminder": {
+        'task': 'email_reminder',
+        'schedule': crontab(minute=0) # every hour
+    },
+    "incident_cleaning": {
+        'task': 'incident_cleaning',
+        'schedule': crontab(hour=20, minute=30)
+    },
+    "log_cleaning": {
+        'task': 'log_cleaning',
+        'schedule': crontab(hour=21, minute=00)
+    },
+    "workflow_update_status": {
+        'task': 'workflow_update_status',
+        'schedule': crontab(minute=0) # every hour
+    },
+    "unactive_account_cleaning": {
+        'task': 'unactive_account_cleaning',
+        'schedule': crontab(minute=0) # every hour
+    },
+#    "every_10_seconds": {
+#        'task': 'taskname',
+#        'schedule': 10.0 # every 10 seconds
+#    },
+}

--- a/celery_beat.py
+++ b/celery_beat.py
@@ -10,7 +10,7 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 app.conf.beat_schedule = {
     "email_reminder": {
         'task': 'email_reminder',
-        'schedule': crontab(minute=0) # every hour
+        'schedule': crontab(minute=0)  # every hour
     },
     "incident_cleaning": {
         'task': 'incident_cleaning',
@@ -22,14 +22,10 @@ app.conf.beat_schedule = {
     },
     "workflow_update_status": {
         'task': 'workflow_update_status',
-        'schedule': crontab(minute=0) # every hour
+        'schedule': crontab(minute=0)  # every hour
     },
     "unactive_account_cleaning": {
         'task': 'unactive_account_cleaning',
-        'schedule': crontab(minute=0) # every hour
+        'schedule': crontab(minute=0)  # every hour
     },
-#    "every_10_seconds": {
-#        'task': 'taskname',
-#        'schedule': 10.0 # every 10 seconds
-#    },
 }

--- a/celery_worker.py
+++ b/celery_worker.py
@@ -5,5 +5,5 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'governanceplatform.settings')
 
 app = Celery('governanceplatform')
 app.config_from_object('django.conf:settings', namespace='CELERY')
-app.autodiscover_tasks()
-app.autodiscover_tasks(['reporting'])
+
+app.autodiscover_tasks(['reporting', 'incidents', 'governanceplatform'])

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,6 @@ FROM python:3.11-bullseye
 
 ARG APP_VERSION
 ARG GUNICORN_VERSION=23.0
-ARG MULTIRUN_VERSION=1.1.3
 ENV APP_VERSION=$APP_VERSION
 
 WORKDIR /app
@@ -20,8 +19,6 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gettext \
   && rm -rf /var/lib/apt/lists/*
-
-RUN wget -c https://github.com/nicolas-van/multirun/releases/download/${MULTIRUN_VERSION}/multirun-x86_64-linux-gnu-${MULTIRUN_VERSION}.tar.gz -O - | tar -C /bin -xz
 
 # running as www-data, we need homedir and PATH for --user installed pip modules
 RUN mkdir -p /app /var/www && chown www-data: /app /var/www
@@ -46,7 +43,9 @@ COPY --chown=www-data manage.py /app/manage.py
 RUN python3 -m pip install --user .
 RUN python3 -m pip install --user gunicorn~=$GUNICORN_VERSION
 
-COPY cronjob.py /app/cronjob.py
+COPY celery_worker.py /app/
+COPY celery_beat.py /app/
+
 COPY docker/docker-init.sh /app/docker-init.sh
 
 ENTRYPOINT [ "/app/docker-init.sh" ]

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -5,23 +5,58 @@ services:
     pull_policy: always
     environment: &env
       DEBUG: "false"
-      POSTGRES_USER: "<user>"
-      POSTGRES_PASSWORD: "<password>"
-      POSTGRES_DB: "serima-governance"
+      POSTGRES_USER: "governanceplatform"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD?:err}"
+      POSTGRES_DB: "governanceplatform"
       POSTGRES_HOST: "postgres"
+      CELERY_BROKER_URL: 'redis://redis:6379/0'
+      CELERY_RESULT_BACKEND: 'redis://redis:6379/1'
+      SUPERUSER_EMAIL: "${SUPERUSER_EMAIL}" # not set if empty
+      SUPERUSER_PASSWORD: "${SUPERUSER_PASSWORD}" # not set if empty
+      MAIN_SITE: "${MAIN_SITE}" # not set if empty
+      MAIN_SITE_NAME: "${MAIN_SITE_NAME}" # not set if empty
     ports:
       - "8888:8888"
     volumes:
       - ./volumes/config/config.py:/app/governanceplatform/config.py:ro
-      # the below volumes need to be writable by www-data (uid 33)
-      - ./volumes/default-theme:/app/theme
+      - theme:/app/theme
     restart: unless-stopped
   postgres:
     container_name: governanceplatform-postgres-${NISINP_ENVIRONMENT?:err}
     image: postgres:15
+    environment: *env
+    restart: unless-stopped
     volumes:
       - ./volumes/postgres/data:/var/lib/postgresql/data
       # enable the below volume if you want to load a pg_dump at init
       #- ./volumes/postgres/initdb.d:/docker-entrypoint-initdb.d
-    environment: *env
+  theme:
+    container_name: governanceplatform-theme-${NISINP_ENVIRONMENT?:err}
+    image: ${THEME_IMAGE:-ghcr.io/informed-governance-project/default-theme}:${THEME_VERSION?:err}
+    volumes:
+      - theme:/app/theme
     restart: unless-stopped
+  celery-worker:
+    container_name: governanceplatform-celery-worker-${NISINP_ENVIRONMENT?:err}
+    image: ${NISINP_IMAGE:-ghcr.io/informed-governance-project/nisinp}:${NISINP_VERSION?:err}
+    pull_policy: always
+    environment: *env
+    command: worker
+    volumes:
+      - ./volumes/config/config.py:/app/governanceplatform/config.py:ro
+  celery-beat:
+    container_name: governanceplatform-celery-beat-${NISINP_ENVIRONMENT?:err}
+    image: ${NISINP_IMAGE:-ghcr.io/informed-governance-project/nisinp}:${NISINP_VERSION?:err}
+    pull_policy: always
+    environment: *env
+    command: beat
+    volumes:
+      - ./volumes/config/config.py:/app/governanceplatform/config.py:ro
+  redis:
+    container_name: governanceplatform-redis-${NISINP_ENVIRONMENT?:err}
+    image: docker.io/redis:7-alpine
+    volumes:
+      - ./volumes/redis/data:/data
+
+volumes:
+  theme:

--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 
+
+debug="${DEBUG:-false}"
+component="${1:-app}"
+
+SUPERUSER_EMAIL="${SUPERUSER_EMAIL:-}"
+SUPERUSER_PASSWORD="${SUPERUSER_PASSWORD:-}"
+MAIN_SITE="${MAIN_SITE:-}"
+MAIN_SITE_NAME="${MAIN_SITE_NAME:-}"
+
 set -euo pipefail
+
+if [ "$debug" != "false" ]; then
+    echo $debug
+    pwd
+    set -x
+fi
 
 docker_init_d=/docker-init.d
 if [ -d $docker_init_d -a $docker_init_d/*.sh != "${docker_init_d}/*.sh" ]; then
@@ -9,10 +24,46 @@ if [ -d $docker_init_d -a $docker_init_d/*.sh != "${docker_init_d}/*.sh" ]; then
     done
 fi
 
-mkdir -p /app/theme/static
 
-python manage.py collectstatic --noinput > /dev/null
-python manage.py migrate
-python manage.py compilemessages
+case "$component" in
+    app)
+        mkdir -p /app/theme/static
 
-exec multirun "gunicorn governanceplatform.wsgi --workers '$APP_WORKERS' --bind '$APP_BIND_ADDRESS:$APP_PORT'" "/app/cronjob.py"
+        python manage.py collectstatic --noinput > /dev/null
+        python manage.py migrate
+        python manage.py compilemessages
+
+        if [ "$SUPERUSER_EMAIL" -a "$SUPERUSER_PASSWORD" ]; then
+            echo >&2 "INFO: setting $SUPERUSER_EMAIL as superuser"
+            python manage.py shell --interface python <<END
+from governanceplatform import models
+if not User.objects.filter(email='${SUPERUSER_EMAIL}'):
+    u = User.objects.create_superuser('${SUPERUSER_EMAIL}', '${SUPERUSER_PASSWORD}')
+END
+        fi
+
+        if [ "$MAIN_SITE" -a "$MAIN_SITE_NAME" ]; then
+            echo >&2 "INFO: setting $MAIN_SITE ($MAIN_SITE_NAME) as django_site information"
+            python manage.py shell --interface python <<END
+from django.contrib.sites.models import Site
+site = Site.objects.all()[0]
+site.domain = "${MAIN_SITE}"
+site.name = "${MAIN_SITE_NAME}"
+site.save()
+END
+        fi
+
+        exec gunicorn governanceplatform.wsgi --workers "$APP_WORKERS" --bind "$APP_BIND_ADDRESS:$APP_PORT"
+        ;;
+    worker)
+        exec celery -A celery_worker worker --loglevel=info
+        ;;
+    beat)
+        exec celery -A celery_beat beat --loglevel=info
+        ;;
+    *)
+        echo >&2 "unknown component in entrypoint $(basename $0)"
+        exit 1
+        ;;
+esac
+

--- a/governanceplatform/__init__.py
+++ b/governanceplatform/__init__.py
@@ -1,5 +1,3 @@
 from governanceplatform import tools
-from .celery import app as celery_app
 
 __version__ = tools.get_version()
-__all__ = ['celery_app']

--- a/governanceplatform/scripts/unactive_account_cleaning.py
+++ b/governanceplatform/scripts/unactive_account_cleaning.py
@@ -7,11 +7,13 @@ from governanceplatform.models import ScriptLogEntry
 from governanceplatform.settings import ACCOUNT_ACTIVATION_LINK_TIMEOUT
 from governanceplatform.models import User
 
-logger = logging.getLogger(__name__)
+from celery import shared_task
 
+logger = logging.getLogger(__name__)
 
 # Script to run every hour
 # remove users who are inactive, never logged, and recently joined
+@shared_task(name="unactive_account_cleaning")
 def run(logger=logger):
     logger.info("running incident_cleaning.py")
     # for all closed incident

--- a/governanceplatform/scripts/unactive_account_cleaning.py
+++ b/governanceplatform/scripts/unactive_account_cleaning.py
@@ -11,6 +11,7 @@ from celery import shared_task
 
 logger = logging.getLogger(__name__)
 
+
 # Script to run every hour
 # remove users who are inactive, never logged, and recently joined
 @shared_task(name="unactive_account_cleaning")

--- a/governanceplatform/scripts/update_all_group_permissions.py
+++ b/governanceplatform/scripts/update_all_group_permissions.py
@@ -2,10 +2,13 @@ import logging
 
 from governanceplatform.permissions import update_all_group_permissions
 
+from celery import shared_task
+
 logger = logging.getLogger(__name__)
 
 
 # Script to run once when group permissions change
+@shared_task(name="update_all_group_permissions")
 def run(logger=logger):
     logger.info("updating group pemissions")
     update_all_group_permissions()

--- a/governanceplatform/tasks.py
+++ b/governanceplatform/tasks.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import logging
+import os
+
+import django
+
+# django init
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "governanceplatform.settings")
+django.setup()
+
+from governanceplatform.scripts import (  # noqa: E402
+    unactive_account_cleaning,
+    update_all_group_permissions,
+)

--- a/governanceplatform/tasks.py
+++ b/governanceplatform/tasks.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import logging
 import os
 
 import django
@@ -9,7 +8,7 @@ import django
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "governanceplatform.settings")
 django.setup()
 
-from governanceplatform.scripts import (  # noqa: E402
+from governanceplatform.scripts import (  # noqa: E402 F401
     unactive_account_cleaning,
     update_all_group_permissions,
 )

--- a/incidents/scripts/email_reminder.py
+++ b/incidents/scripts/email_reminder.py
@@ -11,10 +11,13 @@ from incidents.models import (
     SectorRegulationWorkflowEmail,
 )
 
+from celery import shared_task
+
 logger = logging.getLogger(__name__)
 
 
 # Script to run every hour
+@shared_task(name="email_reminder")
 def run(logger=logger):
     logger.info("running email_reminder.py")
     # for all unclosed incident

--- a/incidents/scripts/incident_cleaning.py
+++ b/incidents/scripts/incident_cleaning.py
@@ -7,11 +7,14 @@ from governanceplatform.models import ScriptLogEntry
 from governanceplatform.settings import INCIDENT_RETENTION_TIME_IN_DAY
 from incidents.models import Incident
 
+from celery import shared_task
+
 logger = logging.getLogger(__name__)
 
 
 # Script to run once day
 # remove incidents after a period configured in config.py
+@shared_task(name="incident_cleaning")
 def run(logger=logger):
     logger.info("running incident_cleaning.py")
     # for all closed incident

--- a/incidents/scripts/log_cleaning.py
+++ b/incidents/scripts/log_cleaning.py
@@ -7,11 +7,14 @@ from django.db.models.functions import Now
 from governanceplatform.models import ScriptLogEntry
 from governanceplatform.settings import LOG_RETENTION_TIME_IN_DAY
 
+from celery import shared_task
+
 logger = logging.getLogger(__name__)
 
 
 # Script to run once day
 # remove log after a period configured in config.py
+@shared_task(name="log_cleaning")
 def run(logger=logger):
     logger.info("running log_cleaning.py")
     log_to_delete = LogEntry.objects.filter(

--- a/incidents/scripts/workflow_update_status.py
+++ b/incidents/scripts/workflow_update_status.py
@@ -11,6 +11,7 @@ from celery import shared_task
 
 logger = logging.getLogger(__name__)
 
+
 # Script to run every hour
 # Send an email when the delay is overdue
 # The status change is managed in frontend

--- a/incidents/scripts/workflow_update_status.py
+++ b/incidents/scripts/workflow_update_status.py
@@ -7,12 +7,14 @@ from django.utils import timezone
 from incidents.email import send_email
 from incidents.models import Incident, IncidentWorkflow, SectorRegulationWorkflow
 
-logger = logging.getLogger(__name__)
+from celery import shared_task
 
+logger = logging.getLogger(__name__)
 
 # Script to run every hour
 # Send an email when the delay is overdue
 # The status change is managed in frontend
+@shared_task(name="workflow_update_status")
 def run(logger=logger):
     logger.info("running workflow_update_status.py")
     # for all unclosed incident

--- a/incidents/tasks.py
+++ b/incidents/tasks.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import logging
+import os
+
+import django
+
+# django init
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "governanceplatform.settings")
+django.setup()
+
+from incidents.scripts import (  # noqa: E402
+    email_reminder,
+    incident_cleaning,
+    log_cleaning,
+    workflow_update_status,
+)

--- a/incidents/tasks.py
+++ b/incidents/tasks.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import logging
 import os
 
 import django
@@ -9,7 +8,7 @@ import django
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "governanceplatform.settings")
 django.setup()
 
-from incidents.scripts import (  # noqa: E402
+from incidents.scripts import (  # noqa: E402 F401
     email_reminder,
     incident_cleaning,
     log_cleaning,


### PR DESCRIPTION
#### What does it do?

- [celery] celery worker with shared_tasks extended to scheduled jobs
- [celery] celery beat to schedule jobs instead of python schedule
- [docker] celery worker and beat docker integration
- [docker] docker django superuser creation on init (via env var) helper
- [docker] docker django site init (via env var) helper
- [docker] docker-init update with app/worker/beat commands arg
- [doc] docker-compose example update
- [doc] docker deployment documentation update

#### Questions

- [ ] Does it require a DB change? no
- [ ] Are you using it in production? no

#### Release Type:
- [x] Major
- [ ] Minor
- [ ] Patch
