### PR TITLE
[fix] Guard debug_toolbar import to prevent production crash

### DIFF
--- a/governanceplatform/settings.py
+++ b/governanceplatform/settings.py
@@ -195,20 +195,25 @@ INTERNAL_IPS = [
 ]
 
 if DEBUG and not os.environ.get("READTHEDOCS"):
-    INSTALLED_APPS.append("debug_toolbar")
-    MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
-    context_processors.append("django.template.context_processors.debug")
-    import socket
+    try:
+        import debug_toolbar  # noqa: F401
 
-    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
-    INTERNAL_IPS = [ip[:-1] + "1" for ip in ips] + ["127.0.0.1", "10.0.2.2"]
-    DEBUG_TOOLBAR_CONFIG = {
-        "INTERCEPT_REDIRECTS": False,
-        "SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG,
-        "RESULTS_CACHE_SIZE": 3,
-        "SHOW_COLLAPSED": True,
-        "SQL_WARNING_THRESHOLD": 100,
-    }
+        INSTALLED_APPS.append("debug_toolbar")
+        MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
+        context_processors.append("django.template.context_processors.debug")
+        import socket
+
+        hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
+        INTERNAL_IPS = [ip[:-1] + "1" for ip in ips] + ["127.0.0.1", "10.0.2.2"]
+        DEBUG_TOOLBAR_CONFIG = {
+            "INTERCEPT_REDIRECTS": False,
+            "SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG,
+            "RESULTS_CACHE_SIZE": 3,
+            "SHOW_COLLAPSED": True,
+            "SQL_WARNING_THRESHOLD": 100,
+        }
+    except ImportError:
+        pass
 
 
 ROOT_URLCONF = "governanceplatform.urls"


### PR DESCRIPTION
## Summary

- Wraps `debug_toolbar` setup in `try/except ImportError` so the app doesn't crash when the package isn't installed
- When deploying with Docker Compose, if `config.py` is missing, `config_dev.py` is used as fallback with `DEBUG=True`, triggering the `debug_toolbar` import — which isn't in the production image
- All containers (`governanceplatform`, `celery-worker`, `celery-beat`) crash-loop with `ModuleNotFoundError: No module named 'debug_toolbar'`

## Test plan

- [ ] Deploy with `DEBUG=True` and **without** `debug_toolbar` installed — app should start without error
- [ ] Deploy with `DEBUG=True` and **with** `debug_toolbar` installed — toolbar should work as before
- [ ] Deploy with `DEBUG=False` — no change in behavior

Fixes #641