### PR TITLE
[docker] Update Node base image to node:22-bookworm-slim (LTS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bootstrap version update in governance settings
 
 ### Changed
-- Docker `npmbuilder` stage updated from `node:24-bookworm-slim` to `node:current-slim`
-- Docker runtime stage updated from `ubuntu:24.04` to `ubuntu:latest`
+- Docker `npmbuilder` stage updated from `node:24-bookworm-slim` to `node:22-bookworm-slim` (Node 22 LTS, supported until April 2027)
 - Superuser access restricted in `RestrictViewsMiddleware` (#646)
 - Removed 'delete' permission for 'company' in RegulatorUser group (#646)
 - Permissions cleanup: consolidated controls into `permission.py` (#646)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,563 @@
+# Changelog
+
+All notable changes to NISINP are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Django 6 upgrade with custom django-parler fork
+- Enhanced sectors filter in incident notifications (#670)
+- Impacts choices in incident export (#677)
+- Permission centralisation in `permission.py` (#646)
+- `get_sectors_grouped` helper
+- `django.contrib.postgres` added to INSTALLED_APPS (#635)
+- Sectors readonly field for OperatorAdmin in CompanyAdmin
+- User deactivation via signals and improved user validation decorator (#646)
+- Bootstrap version update in governance settings
+
+### Changed
+- Superuser access restricted in `RestrictViewsMiddleware` (#646)
+- Removed 'delete' permission for 'company' in RegulatorUser group (#646)
+- Permissions cleanup: consolidated controls into `permission.py` (#646)
+- `log_action` function fixed for Django 6 compatibility (#635)
+
+---
+
+## [0.5.13] - 2026-03-26
+
+### Added
+- Dokploy docker-compose deployment support
+- `img` tag support with `alt`, `src`, and `width` attributes in admin rich text (#604)
+- Sectors field on company for reporting (#639)
+
+### Changed
+- Excluded sectors without children from choice list for operators
+- Dependency updates
+
+---
+
+## [0.5.12] - 2026-02-25
+
+### Added
+- Honeypot captcha on password reset form (#617)
+- Full IP-based validator with migration (#617)
+- Captcha field in password reset and signup forms (#617)
+- Optional SMTP authentication settings
+- Role tag display in incident logs (#600)
+- Simplified incident log creation logic (#600)
+
+### Fixed
+- Translation placeholders in validator admin (#621)
+- OTP debug mode: bypass OTP setup for new users, preserve for existing ones (#664, #665)
+
+### Changed
+- Docker base image upgraded to Python 3.12
+- 2FA reset rules updated for RegulatorUser (#577)
+- HOME environment variable set for `www-data` in Docker
+
+---
+
+## [0.5.11] - 2026-01-26
+
+### Added
+- Filter by regulator on incident list for RegulatorUser (#603)
+
+### Fixed
+- HTTP error response status codes in access log and export views (#603)
+- Escaped and handled `None` values in incident workflow comments
+- Modal error response format (#603)
+
+### Changed
+- Removed function to assign sector to operators (#593)
+- `gettext_lazy` used throughout admin display decorators for translations (#586)
+
+---
+
+## [0.5.10] - 2025-12-09
+
+### Added
+- Multilingual email content support (#533)
+- Configuration variables view (#543)
+- `onchange` classes on review status form (#557)
+
+### Fixed
+- RegulatorAdmin 2FA reset rules (#550)
+- Prevent RegulatorUser from seeing ObserverUser and resetting 2FA (#550)
+- Celery task running (#542)
+
+### Changed
+- Script to delete incident users and remove debug traces (#542)
+
+---
+
+## [0.5.9] - 2025-11-12
+
+### Added
+- Incident export with file format selection (CSV, XLSX) (#441)
+- XLSX export format support via openpyxl (#441)
+- Email notification for PlatformAdmin on mass incident export (#441)
+- `sectorregulation` field in incident export (#441)
+
+### Fixed
+- Question duplication in admin: appends `(copy)` to unique fields (#522)
+- `Functionality` choices use a callable to fix dynamic choices in migrations
+
+### Changed
+- Removed `sectors` field from `CompanyUser` model; factorised operator permission helpers (#487)
+
+---
+
+## [0.5.8] - 2025-10-14
+
+### Added
+- Search field for Governance module (#448)
+- Sort on all model fields in Governance module (#448)
+- Status log entry created when report status changes (#449)
+
+### Fixed
+- `maxDate` format in Dominus date widget (#468)
+- PlatformAdmin redirection to admin page on login
+- PDF filename timestamp format (#500)
+- Report status limited to valid choices with default (#499)
+- Redirect to first report when only one unique sector regulation (#501)
+
+---
+
+## [0.5.7] - 2025-09-15
+
+### Added
+- Cookies policy and sitemap views (#454)
+- Sitemap includes home, account, and notification URLs (#454)
+- Custom authentication form with enhanced login validation and inactive user handling (#461)
+
+### Fixed
+- Incident user validation in `CompanyUser` model (#459)
+- Email address normalised (lowercased) on registration (#460)
+- Incident attached to first approved company when user linked to several (#469)
+- Only approved companies proposed in company selector (#469)
+
+### Changed
+- Incident delta calculated from detection date on incident only
+
+---
+
+## [0.5.6] - 2025-08-28
+
+### Added
+- `min_date` support in `TempusDominusV6Widget` (#183)
+- Timeline form pre-filled with data from previous report (#183)
+
+### Fixed
+- Incident date handling in PDF report generation (#183)
+- Date validation in `IncidenteDateForm` (#183)
+- Resolution date conversion for report timeline (#183)
+
+---
+
+## [0.5.5] - 2025-06-24
+
+### Added
+- Celery async task queue with Redis broker
+- Docker volumes for `shared_dir` and theme for Celery workers
+- `update_group_permissions` command run at Docker startup
+- Debug toolbar conditionally loaded via environment variable
+- `poetry-plugin-export` added to pre-commit configuration
+
+### Fixed
+- Incident report limit check logic and datetime field warnings
+
+### Changed
+- Update script uses `APP_TAG` and `THEME_TAG` variables for clearer deployment
+- Cronjob and `update_all_group_permissions` script replaced by Docker startup command
+
+---
+
+## [0.5.4] - 2025-04-24
+
+### Added
+- `FROM` field in configuration for contact form sender address
+
+---
+
+## [0.5.3] - 2025-04-23
+
+### Fixed
+- Form attributes for `QuestionForm` with multiple-choice questions (#326)
+- Reply-to header added to contact form emails
+
+---
+
+## [0.5.2] - 2025-04-16
+
+### Added
+- Method to retrieve sectors that have no children
+
+### Fixed
+- `EMAIL_FOR_CONTACT` now reads `contact_email` from `REGULATOR_CONTACT` config
+- `PUBLIC_URL` and `SITE_NAME` read from environment variables in dev config
+
+---
+
+## [0.3.9] - 2025-01-08
+
+### Fixed
+- Admin queryset limitation removed for new question categories (#260)
+
+---
+
+## [0.3.8] - 2025-01-06
+
+### Fixed
+- Set correct permission when PlatformAdmin creates a user (#259)
+
+---
+
+## [0.3.7] - 2025-01-03
+
+### Changed
+- Theme update
+
+---
+
+## [0.3.6] - 2025-01-02
+
+### Added
+- Docker deployment with `docker-compose` and Gunicorn production setup
+- Docker cron script for scheduled tasks
+- GitHub Actions Docker build and push workflow
+- `APP_VERSION` injected at Docker build time
+- Bind address configurable via environment variable
+
+---
+
+## [0.3.5] - 2024-12-19
+
+### Added
+- Tag selection in the `update.sh` deployment script
+
+---
+
+## [0.3.4] - 2024-12-18
+
+### Fixed
+- Incident table filter now persists sector choices in session (#250)
+- Initial values correctly selected in dropdown checkboxes (#249)
+- `CompanyUser` existence checked before saving to avoid errors (#246)
+
+---
+
+## [0.3.3] - 2024-12-17
+
+### Changed
+- Translation updates (BE, FR, NL)
+
+---
+
+## [0.3.2] - 2024-12-05
+
+### Added
+- Debug toolbar documentation
+- Documentation updates and fixes
+
+---
+
+## [0.3.1] - 2024-11-27
+
+### Added
+- Timeline section for reports in PDF output
+
+### Fixed
+- Password minimum length enforced to 12 characters (#231)
+- CSRF cookie age configured
+- PDF and incident list renamed for clarity (#230)
+
+---
+
+## [0.3.0] - 2024-11-22
+
+### Added
+- Message reminder mixin for unsaved changes (#229)
+
+### Fixed
+- Multiple UI and logic issues (#225–#228)
+- `entity_categories` field set to readonly for non-RegulatorUser roles
+- Incidents queryset ordered consistently
+
+---
+
+## [0.2.9] - 2024-11-13
+
+### Added
+- Security objectives app (`securityobjectives`)
+- Log entry created when an operator reads a comment in security objectives
+
+---
+
+## [0.2.8] - 2024-10-29
+
+### Fixed
+- Category and question option ordering in admin
+- New report no longer shows all categories (only applicable ones)
+- `QuestionCategoryOptions` model: removed unnecessary `report` foreign key
+
+---
+
+## [0.2.7] - 2024-10-10
+
+### Added
+- Check preventing deletion of a workflow that is in use (#211)
+
+### Fixed
+- Answer rendering for RL questions in PDF
+- Various queryset and form ID fixes
+
+---
+
+## [0.2.6] - 2024-09-19
+
+### Added
+- Impact ordering in reports (#190)
+
+### Fixed
+- Operators and regulators now share the same incident history view (#184)
+
+---
+
+## [0.2.5] - 2024-09-04
+
+### Fixed
+- Language translation issues (#172)
+- Observer inline queryset in admin
+
+### Changed
+- Import/export disabled for certain models (#171)
+- Removed `receive_all_incident` field from regulator
+
+---
+
+## [0.2.4] - 2024-08-13
+
+### Added
+- `pytz` timezone library dependency
+
+### Fixed
+- Database migration errors on clean database
+
+---
+
+## [0.2.3] - 2024-08-05
+
+### Fixed
+- Base URL path for WeasyPrint PDF report generation
+
+---
+
+## [0.2.2] - 2024-05-30
+
+### Fixed
+- Security vulnerability (#154)
+- CodeQL-reported security issue (CVE-2023-32681 / GHSA-j8r2-6x86-q33q in `requests`)
+
+---
+
+## [0.2.1] - 2024-05-30
+
+### Added
+- Incident list view for RegulatorUser
+- Import/export for questions, predefined answers, and question categories
+- Documentation for question import/export and user interface
+
+### Fixed
+- Email template import issue
+- Sector choice list in impacts
+
+---
+
+## [0.2.0] - 2024-04-10
+
+### Added
+- Improved incident list layout with clear visual separation
+
+### Fixed
+- Translation issues in `globals.py` (#140)
+- User rights retained when companies are still linked (#119)
+
+---
+
+## [0.1.12] - 2024-04-03
+
+### Changed
+- Light theme is now the default
+
+### Fixed
+- Significant impact flag not properly set to `false`
+
+---
+
+## [0.1.11] - 2024-04-03
+
+### Added
+- Default timezone set to `Europe/Paris`
+
+### Fixed
+- RegulatorUser unable to access PDF and incident history
+- RegulatorUser unable to modify status, significant impact, and incident ID
+
+---
+
+## [0.1.10] - 2024-04-03
+
+### Fixed
+- RegulatorUser unable to access an incident
+- Model choices field accepts only valid two-item iterables
+
+---
+
+## [0.1.9] - 2024-04-03
+
+### Changed
+- Release bump
+
+---
+
+## [0.1.7] - 2024-04-03
+
+### Fixed
+- Issue when a user is linked to multiple sectors within a company
+
+---
+
+## [0.1.6] - 2024-03-27
+
+### Added
+- PlatformAdmin can now create PlatformAdmin, CertUser, and RegulatorUser accounts (#52)
+- Documentation: Django Sites configuration, email notifications, admin panel screenshots
+
+### Fixed
+- Sector query limited to sectors covered by `SectorRegulations`
+- Notification date typo
+- Incident starting date handling when null
+- Workflow save when detection date is missing from form
+
+---
+
+## [0.1.5] - 2024-03-20
+
+### Changed
+- Release bump
+
+---
+
+## [0.1.4] - 2024-02-26
+
+### Added
+- Incident list view for CERT users (#105)
+- Security enforcement on workflow editing
+- Access check before `create_workflow`
+
+### Fixed
+- OperatorAdmin view and queryset (#118)
+- CERT and RegulatorUser role separation (#105)
+
+---
+
+## [0.1.3] - 2024-02-09
+
+### Added
+- Timeline section in each report
+- Incident history column in operator incident list (#100)
+- Regulation filter for impacts
+- Impact ordering in incident reports (#93)
+
+### Fixed
+- Various sector and company selection issues
+
+---
+
+## [0.1.2] - 2024-02-01
+
+### Added
+- Pagination on operator incident list
+- Impacts displayed grouped by sector (#99)
+
+### Fixed
+- CL/RL question handling
+- Pagination on regulator incident list (#90)
+
+---
+
+## [0.1.1] - 2024-01-26
+
+### Added
+- First draft for incident history in regulator view
+- Operator incident list with filters and sort (#88)
+
+### Fixed
+- Company deletion prevented when users are attached (#73)
+- Sector creation and edit issues
+- Sector fetching with multilingual support (#88)
+
+---
+
+## [0.1.0] - 2023-09-14
+
+### Added
+- Initial release of the NISINP governance platform
+- User management with PlatformAdmin, RegulatorAdmin, RegulatorUser, OperatorAdmin, OperatorUser, and ObserverUser roles
+- Incident notification workflow with multi-step reports
+- Two-factor authentication (TOTP via `django-otp`)
+- Multilingual support (EN, FR, NL, DE) via `django-parler`
+- REST API (feature-flagged) via Django REST Framework
+- PDF report generation via WeasyPrint
+- Admin site with import/export capabilities
+- Email notifications for incident events
+- Bootstrap 5 frontend
+
+[Unreleased]: https://github.com/informed-governance-project/NISINP/compare/v0.5.13...HEAD
+[0.5.13]: https://github.com/informed-governance-project/NISINP/compare/v0.5.12...v0.5.13
+[0.5.12]: https://github.com/informed-governance-project/NISINP/compare/v0.5.11...v0.5.12
+[0.5.11]: https://github.com/informed-governance-project/NISINP/compare/v0.5.10...v0.5.11
+[0.5.10]: https://github.com/informed-governance-project/NISINP/compare/v0.5.9...v0.5.10
+[0.5.9]: https://github.com/informed-governance-project/NISINP/compare/v0.5.8...v0.5.9
+[0.5.8]: https://github.com/informed-governance-project/NISINP/compare/v0.5.7...v0.5.8
+[0.5.7]: https://github.com/informed-governance-project/NISINP/compare/v0.5.6...v0.5.7
+[0.5.6]: https://github.com/informed-governance-project/NISINP/compare/v0.5.5...v0.5.6
+[0.5.5]: https://github.com/informed-governance-project/NISINP/compare/v0.5.4...v0.5.5
+[0.5.4]: https://github.com/informed-governance-project/NISINP/compare/v0.5.3...v0.5.4
+[0.5.3]: https://github.com/informed-governance-project/NISINP/compare/v0.5.2...v0.5.3
+[0.5.2]: https://github.com/informed-governance-project/NISINP/compare/v0.3.9...v0.5.2
+[0.3.9]: https://github.com/informed-governance-project/NISINP/compare/v0.3.8...v0.3.9
+[0.3.8]: https://github.com/informed-governance-project/NISINP/compare/v0.3.7...v0.3.8
+[0.3.7]: https://github.com/informed-governance-project/NISINP/compare/v0.3.6...v0.3.7
+[0.3.6]: https://github.com/informed-governance-project/NISINP/compare/v0.3.5...v0.3.6
+[0.3.5]: https://github.com/informed-governance-project/NISINP/compare/v0.3.4...v0.3.5
+[0.3.4]: https://github.com/informed-governance-project/NISINP/compare/v0.3.3...v0.3.4
+[0.3.3]: https://github.com/informed-governance-project/NISINP/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/informed-governance-project/NISINP/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/informed-governance-project/NISINP/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/informed-governance-project/NISINP/compare/v0.2.9...v0.3.0
+[0.2.9]: https://github.com/informed-governance-project/NISINP/compare/v0.2.8...v0.2.9
+[0.2.8]: https://github.com/informed-governance-project/NISINP/compare/v0.2.7...v0.2.8
+[0.2.7]: https://github.com/informed-governance-project/NISINP/compare/v0.2.6...v0.2.7
+[0.2.6]: https://github.com/informed-governance-project/NISINP/compare/v0.2.5...v0.2.6
+[0.2.5]: https://github.com/informed-governance-project/NISINP/compare/v0.2.4...v0.2.5
+[0.2.4]: https://github.com/informed-governance-project/NISINP/compare/v0.2.3...v0.2.4
+[0.2.3]: https://github.com/informed-governance-project/NISINP/compare/v0.2.2...v0.2.3
+[0.2.2]: https://github.com/informed-governance-project/NISINP/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/informed-governance-project/NISINP/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/informed-governance-project/NISINP/compare/v0.1.12...v0.2.0
+[0.1.12]: https://github.com/informed-governance-project/NISINP/compare/v0.1.11...v0.1.12
+[0.1.11]: https://github.com/informed-governance-project/NISINP/compare/v0.1.10...v0.1.11
+[0.1.10]: https://github.com/informed-governance-project/NISINP/compare/v0.1.9...v0.1.10
+[0.1.9]: https://github.com/informed-governance-project/NISINP/compare/v0.1.7...v0.1.9
+[0.1.7]: https://github.com/informed-governance-project/NISINP/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.com/informed-governance-project/NISINP/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/informed-governance-project/NISINP/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/informed-governance-project/NISINP/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/informed-governance-project/NISINP/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/informed-governance-project/NISINP/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/informed-governance-project/NISINP/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/informed-governance-project/NISINP/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bootstrap version update in governance settings
 
 ### Changed
+- Docker `npmbuilder` stage updated from `node:24-bookworm-slim` to `node:current-slim`
+- Docker runtime stage updated from `ubuntu:24.04` to `ubuntu:latest`
 - Superuser access restricted in `RestrictViewsMiddleware` (#646)
 - Removed 'delete' permission for 'company' in RegulatorUser group (#646)
 - Permissions cleanup: consolidated controls into `permission.py` (#646)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,19 @@ poetry run flake8
 | Add a Celery task | `governanceplatform/tasks.py` or `incidents/tasks.py` |
 | Generate model diagram | `make models` |
 
+## Changelog
+
+`CHANGELOG.md` lives at the repo root and follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+**Every PR that ships user-facing changes must include a `CHANGELOG.md` update.**
+
+Rules:
+- Add entries under `## [Unreleased]` — never edit a released version's section.
+- Use the correct category: `Added` (new feature), `Changed` (behaviour change), `Fixed` (bug fix).
+- Reference the GitHub issue number where one exists, e.g. `Fixed: foo bar (#123)`.
+- When a version is released, rename `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD` and add a fresh empty `[Unreleased]` block above it. Also add the comparison link at the bottom of the file.
+- Omit pure chore entries (dependency bumps, translation updates, theme submodule bumps) unless they affect end-users.
+
 ## CI/CD
 
 GitHub Actions workflows:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-bookworm-slim  AS npmbuilder
+FROM node:current-slim AS npmbuilder
 
 WORKDIR /app
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-slim AS npmbuilder
+FROM node:22-bookworm-slim AS npmbuilder
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY package.json package-lock.json /app/
 
 RUN npm ci
 
-FROM ubuntu:latest
+FROM ubuntu:24.04
 
 ARG APP_VERSION
 ARG GUNICORN_VERSION=23.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ COPY package.json package-lock.json /app/
 
 RUN npm ci
 
-FROM ubuntu:24.04
+FROM ubuntu:latest
 
 ARG APP_VERSION
 ARG GUNICORN_VERSION=23.0


### PR DESCRIPTION
## Generic requirements in order to contribute to SERIMA:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible
* Always make sure it is mergeable in the default branch
* Any major changes adding a functionality should be disabled by default in the configuration of SERIMA

#### What does it do?

Replaces the pinned `node:24-bookworm-slim` base image in the `npmbuilder` stage with `node:current-slim`, which always resolves to the latest stable Node.js release.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch