### PR TITLE
[chore] Update copyright year to 2026

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,9 +1,9 @@
 # Authors
 
-* Copyright (C) 2023-2024 Cédric Bonhomme <cedric.bonhomme@nc3.lu>
-* Copyright (C) 2023-2024 Jérôme Lombardi <jerome.lombardi@nc3.lu>
-* Copyright (C) 2023-2024 Juan Rocha <juan.rocha@nc3.lu>
-* Copyright (C) 2023-2024 Ruslan Baidan <ruslan.baidan@nc3.lu>
+* Copyright (C) 2023-2026 Cédric Bonhomme <cedric.bonhomme@nc3.lu>
+* Copyright (C) 2023-2026 Jérôme Lombardi <jerome.lombardi@nc3.lu>
+* Copyright (C) 2023-2026 Juan Rocha <juan.rocha@nc3.lu>
+* Copyright (C) 2023-2026 Ruslan Baidan <ruslan.baidan@nc3.lu>
 
 The Governance Platform is licensed under
 [GNU Affero General Public License version 3](https://www.gnu.org/licenses/agpl-3.0.html)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ os.environ["READTHEDOCS"] = "True"
 django.setup()
 
 project = "NIS Incident Notification Platform"
-copyright = "2023-2024 Luxembourg House of Cybersecurity"
+copyright = "2023-2026 Luxembourg House of Cybersecurity"
 author = "NC3 Team <info@nc3.lu>"
 
 # The full version, including alpha/beta/rc tags

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,8 +95,8 @@ License
 The Governance Platform is licensed under
 `GNU Affero General Public License version 3 <https://www.gnu.org/licenses/agpl-3.0.html>`_.
 
-- Copyright (C) 2023-2024 Cédric Bonhomme <cedric.bonhomme@nc3.lu>
-- Copyright (C) 2023-2024 Jérôme Lombardi <jerome.lombardi@nc3.lu>
-- Copyright (C) 2023-2024 Juan Rocha <juan.rocha@nc3.lu>
-- Copyright (C) 2023-2024 `NC3 Luxembourg <https://www.nc3.lu>`_
-- Copyright (C) 2023-2024 Ruslan Baidan <ruslan.baidan@nc3.lu>
+- Copyright (C) 2023-2026 Cédric Bonhomme <cedric.bonhomme@nc3.lu>
+- Copyright (C) 2023-2026 Jérôme Lombardi <jerome.lombardi@nc3.lu>
+- Copyright (C) 2023-2026 Juan Rocha <juan.rocha@nc3.lu>
+- Copyright (C) 2023-2026 `NC3 Luxembourg <https://www.nc3.lu>`_
+- Copyright (C) 2023-2026 Ruslan Baidan <ruslan.baidan@nc3.lu>


### PR DESCRIPTION
## Summary

- Update copyright year from 2023-2024 to 2023-2026 in `AUTHORS.md`, `docs/conf.py`, and `docs/index.rst`

## Test plan

- [ ] Verify copyright strings read `2023-2026` in all three files
- [ ] Confirm Sphinx doc build still succeeds (no functional change)