### PR TITLE
[docs] Add missing CHANGELOG entry for email formatting fix (#668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `plotly_get_chrome` now runs non-interactively during Docker build to avoid `EOFError` (#679)
+- Email formatting: markdown and sanitization steps now correctly scoped inside the per-language conditional block in `render_to_string_multi_languages` (#668)
 
 ### Changed
 - `cryptography` updated from 46.x to 47.x (#679)


### PR DESCRIPTION
## Summary

- Adds the missing `Fixed` entry in `CHANGELOG.md` for commit `a6d75dbc` which fixed a bug in `render_to_string_multi_languages` where `markdown()` and `sanitize_html()` calls were outside their per-language conditional block (#668).

## Test plan

- [ ] Verify the `[Unreleased]` section of `CHANGELOG.md` contains the email formatting fix under `### Fixed`