### PR TITLE
fix: remove dead code in registration_view get_or_create branch

### DIFF
--- a/governanceplatform/views.py
+++ b/governanceplatform/views.py
@@ -157,11 +157,8 @@ def registration_view(request, *args, **kwargs):
             user.accepted_terms_date = Now()
             user.save()
             # default give the role IncidentUser
-            new_group, created = Group.objects.get_or_create(name="IncidentUser")
-            if new_group:
-                user.groups.add(new_group)
-            else:
-                user.groups.add(created)
+            new_group, _ = Group.objects.get_or_create(name="IncidentUser")
+            user.groups.add(new_group)
 
             # Send password reset email
             reset_form = PasswordResetForm({"email": user.email})


### PR DESCRIPTION
Closes #692

## Changes

`Group.objects.get_or_create()` returns `(Group, bool)`. The `else` branch passing the boolean `created` to `user.groups.add()` was dead code (the `if new_group` condition is always `True`) and would have raised `TypeError` if somehow reached.

- Remove the unreachable `else` branch
- Rename `created` to `_` since the boolean is not needed

## Test plan
- [ ] Run `poetry run pytest governanceplatform/tests/` — existing registration tests still pass