### PR TITLE
test: filter parameterised URLs in test_superuser_restricted_access

### DIFF
--- a/governanceplatform/tests/test_views.py
+++ b/governanceplatform/tests/test_views.py
@@ -136,6 +136,10 @@ def test_superuser_restricted_access(otp_client, populate_db):
     u.is_superuser = True
     u.save()
     client = otp_client(u)
-    for url in list_urls(get_resolver().url_patterns):
+    all_urls = list_urls(get_resolver().url_patterns)
+    # Exclude parameterised patterns: raw strings like "<int:pk>" don't resolve,
+    # so Django would 404 for the wrong reason (no URL match, not middleware block).
+    simple_urls = [url for url in all_urls if "<" not in url]
+    for url in simple_urls:
         response = client.get(url)
         assert response.status_code == 404


### PR DESCRIPTION
Closes #693

## Changes

`list_urls()` returns raw URL strings including unresolved capture groups like `incidents/incident/<int:pk>/`. When passed to `client.get()`, Django returns 404 because the literal `<int:pk>` string doesn't match the URL converter — not because the superuser middleware fired. The assertions were passing vacuously.

Filter out any URL containing `<` before iterating so only truly parameterless routes are tested against the middleware.

## Test plan
- [ ] Run `poetry run pytest governanceplatform/tests/test_views.py::test_superuser_restricted_access`
- [ ] Confirm the test still passes and the set of URLs exercised is non-empty