### PR TITLE
fix: remove duplicate assignment in select_company view

### DIFF
--- a/governanceplatform/views.py
+++ b/governanceplatform/views.py
@@ -227,7 +227,7 @@ def select_company(request):
             return index(request)
 
     else:
-        form = form = SelectCompany(
+        form = SelectCompany(
             companies=request.user.companies.filter(
                 companyuser__approved=True
             ).distinct(),


### PR DESCRIPTION
Closes #695

## Changes

Removed copy-paste artefact `form = form = SelectCompany(...)` — the double assignment has no runtime effect but is confusing and linter-flagged.

## Test plan
- [ ] Run `poetry run pytest governanceplatform/tests/` — no regression