### PR TITLE
test: select IncidentUser explicitly in test_superuser_restricted_access

### DIFF
--- a/governanceplatform/tests/test_views.py
+++ b/governanceplatform/tests/test_views.py
@@ -132,7 +132,7 @@ def test_superuser_restricted_access(otp_client, populate_db):
     Verify that a superuser cannot access the platform
     """
     users = populate_db["users"]
-    u = users[0]
+    u = next(user for user in users if user_in_group(user, "IncidentUser"))
     u.is_superuser = True
     u.save()
     client = otp_client(u)


### PR DESCRIPTION
Closes #697

## Changes

Replaced `users[0]` (implicit fixture ordering) with an explicit lookup:
```python
u = next(user for user in users if user_in_group(user, "IncidentUser"))
```

This ensures the promoted user is always a non-privileged `IncidentUser` regardless of fixture ordering.

## Test plan
- [ ] Run `poetry run pytest governanceplatform/tests/test_views.py::test_superuser_restricted_access`