### PR TITLE
fix: cache can_change_or_delete_obj result per object, not per request

### DIFF
--- a/governanceplatform/helpers.py
+++ b/governanceplatform/helpers.py
@@ -252,17 +252,21 @@ def set_creator(request: HttpRequest, obj: Any, change: bool) -> Any:
 
 
 def can_change_or_delete_obj(request: HttpRequest, obj: Any, message="") -> bool:
-    if not hasattr(request, "_can_change_or_delete_obj"):
-        request._can_change_or_delete_obj = True
-    else:
-        return request._can_change_or_delete_obj
+    # Cache per (type, pk) so multiple objects in one request are each evaluated once.
+    cache = getattr(request, "_can_change_or_delete_obj", {})
+    cache_key = (type(obj).__name__, getattr(obj, "pk", None))
+    if cache_key in cache:
+        return cache[cache_key]
+    request._can_change_or_delete_obj = cache
 
     if not obj.pk:
+        cache[cache_key] = True
         return True
 
     creator = getattr(obj, "creator", getattr(obj, "regulator", None))
 
     if not creator:
+        cache[cache_key] = True
         return True
 
     in_use = True
@@ -294,6 +298,7 @@ def can_change_or_delete_obj(request: HttpRequest, obj: Any, message="") -> bool
 
     regulator = request.user.regulators.first()
     if creator == regulator and not in_use:
+        cache[cache_key] = True
         return True
 
     if not message:
@@ -316,8 +321,7 @@ def can_change_or_delete_obj(request: HttpRequest, obj: Any, message="") -> bool
             creator_name=creator_name,
         ),
     )
-    request._can_change_or_delete_obj = False
-
+    cache[cache_key] = False
     return False
 
 


### PR DESCRIPTION
Closes #699

## Problem

`can_change_or_delete_obj` stored a single boolean on the request object. If called for two different objects in the same request (e.g. admin with inlines), the second call returned the first object's cached result — a potential false permission grant or false denial.

## Changes

Replace the single-flag cache with a dict keyed by `(type(obj).__name__, obj.pk)`. Each object is evaluated independently and cached once per request. All return points store the result in the cache before returning.

## Test plan
- [ ] Run `poetry run pytest` — full suite passes
- [ ] Manual test: open an admin change-list that renders multiple `can_change_or_delete_obj` checks in one request and verify correct per-object permission display