### PR TITLE
fix: correct logic inversion in NoReusePasswordValidator

### DIFF
--- a/governanceplatform/validators.py
+++ b/governanceplatform/validators.py
@@ -12,7 +12,7 @@ class NoReusePasswordValidator:
     """
 
     def validate(self, password, user=None):
-        if user or user.pk is None:
+        if not user or user.pk is None:
             return
 
         if user.check_password(password):


### PR DESCRIPTION
Closes #708

## Problem
`if user or user.pk is None:` is always `True` for a real authenticated user, so the validator immediately returned without checking password history — providing zero reuse protection.

## Fix
Changed to `if not user or user.pk is None:` to restore the intended early-exit guard for anonymous users only.

## Test plan
- [ ] Run `poetry run pytest` — full suite passes
- [ ] Manually verify that reusing a previous password is now rejected on the password-change form