### PR TITLE
fix: remove dead if new_group guards in signals.py

### DIFF
--- a/governanceplatform/signals.py
+++ b/governanceplatform/signals.py
@@ -218,19 +218,13 @@ def delete_user_groups(sender, instance, **kwargs):
                     ).exists()
                 ):
                     user.groups.remove(group)
-                    new_group, created = Group.objects.get_or_create(
-                        name="OperatorUser"
-                    )
-                    if new_group:
-                        user.groups.add(new_group)
+                    new_group, _ = Group.objects.get_or_create(name="OperatorUser")
+                    user.groups.add(new_group)
 
                 if group_name == "RegulatorAdmin" and user.regulators.count() < 1:
                     user.groups.remove(group)
-                    new_group, created = Group.objects.get_or_create(
-                        name="RegulatorUser"
-                    )
-                    if new_group:
-                        user.groups.add(new_group)
+                    new_group, _ = Group.objects.get_or_create(name="RegulatorUser")
+                    user.groups.add(new_group)
 
                     user.is_active = False
                     user.save()
@@ -243,10 +237,9 @@ def delete_user_groups(sender, instance, **kwargs):
         if not user.companyuser_set.exists():
             user.is_staff = False
             user.is_superuser = False
-            new_group, created = Group.objects.get_or_create(name="IncidentUser")
-            if new_group:
-                user.groups.clear()
-                user.groups.add(new_group)
+            new_group, _ = Group.objects.get_or_create(name="IncidentUser")
+            user.groups.clear()
+            user.groups.add(new_group)
 
             # Clear contact_user for incidents
             user.incident_set.filter(company__isnull=False).update(contact_user=None)


### PR DESCRIPTION
Closes #709
Closes #720

## Problem
`Group.objects.get_or_create()` always returns a `Group` instance as the first tuple element. Three locations in `delete_user_groups` used `if new_group:` guards that were always `True`, making the `else:` branches dead code.

## Fix
Replaced `(new_group, created)` unpacking + conditional with `(new_group, _)` and unconditional `user.groups.add(new_group)` in all three places (OperatorUser, RegulatorUser, IncidentUser cases).

## Test plan
- [ ] Run `poetry run pytest` — full suite passes