### PR TITLE
refactor: remove redundant else:return in signal handlers

### DIFF
--- a/governanceplatform/signals.py
+++ b/governanceplatform/signals.py
@@ -150,9 +150,7 @@ def update_regulator_user_groups(sender, instance, created, **kwargs):
     if instance.is_regulator_administrator:
         set_regulator_admin_permissions(user)
         return
-    else:
-        set_regulator_staff_permissions(user)
-        return
+    set_regulator_staff_permissions(user)
 
 
 @receiver(post_save, sender=ObserverUser)
@@ -167,9 +165,7 @@ def update_observer_user_groups(sender, instance, created, **kwargs):
     if instance.is_observer_administrator:
         set_observer_admin_permissions(user)
         return
-    else:
-        set_observer_user_permissions(user)
-        return
+    set_observer_user_permissions(user)
 
 
 # mark use for deletion to avoid removing group on inexisting object


### PR DESCRIPTION
Closes #721

## Problem
Both `update_regulator_user_groups` and `update_observer_user_groups` had `if/else` blocks where both branches ended with `return`, making the `else:` keyword redundant and misleading.

## Fix
Removed the `else:` keyword and the trailing `return` from the else branch. The fall-through call (`set_regulator_staff_permissions` / `set_observer_user_permissions`) now appears as the natural path after the early-return `if` block.

## Test plan
- [ ] Run `poetry run pytest` — full suite passes