### PR TITLE
fix: chain otp_required correctly in CustomAdminSite.admin_view

### DIFF
--- a/governanceplatform/admin.py
+++ b/governanceplatform/admin.py
@@ -70,7 +70,7 @@ class CustomAdminSite(admin.AdminSite):
 
     def admin_view(self, view, cacheable=False):
         decorated_view = otp_required(view)
-        decorated_view = check_user_is_correct(view)
+        decorated_view = check_user_is_correct(decorated_view)
         return super().admin_view(decorated_view, cacheable)
 
     def get_app_list(self, request, app_label=None):


### PR DESCRIPTION
Closes #711

## Problem
The result of `otp_required(view)` was immediately overwritten by `check_user_is_correct(view)` (wrapping the original bare view). Admin views were therefore **not OTP-protected** despite the explicit intent.

## Fix
Pass `decorated_view` (the OTP-wrapped view) to `check_user_is_correct` instead of the bare `view`.

```python
# Before
decorated_view = otp_required(view)
decorated_view = check_user_is_correct(view)   # wrapped bare view

# After
decorated_view = otp_required(view)
decorated_view = check_user_is_correct(decorated_view)  # wraps OTP view
```

## Test plan
- [ ] Run `poetry run pytest` — full suite passes
- [ ] Manually verify that accessing admin without a valid OTP now redirects to 2FA setup