### PR TITLE
fix: remove unreachable code in edit_workflow

### DIFF
--- a/incidents/views.py
+++ b/incidents/views.py
@@ -507,8 +507,6 @@ def edit_workflow(request):
     else:
         messages.error(request, _("Forbidden"))
         return redirect("incidents")
-    messages.error(request, _("No incident report could be found."))
-    return redirect("incidents")
 
 
 @login_required


### PR DESCRIPTION
Closes #710

Two lines (messages.error + return redirect) after an unconditional return are dead code, indicating an unhandled control-flow case. Removed the unreachable lines.