### PR TITLE
fix: replace broad except with None check in SectorAdmin.save_model

### DIFF
--- a/governanceplatform/admin.py
+++ b/governanceplatform/admin.py
@@ -223,12 +223,10 @@ class SectorAdmin(CustomTranslatableAdmin):
 
     def save_model(self, request, obj, form, change):
         if not change:
-            try:
-                obj.creator_name = request.user.regulators.all().first().name
-                obj.creator_id = request.user.regulators.all().first().id
-            except Exception:
-                obj.creator_name = Regulator.objects.all().first().name
-                obj.creator_id = Regulator.objects.all().first().id
+            regulator = request.user.regulators.all().first()
+            if regulator is not None:
+                obj.creator_name = regulator.name
+                obj.creator_id = regulator.id
 
         if obj.id and obj.parent is not None:
             if obj.id == obj.parent.id:


### PR DESCRIPTION
Closes #724

The broad except Exception fallback silently assigned the first regulator in the DB as creator when the user had no linked regulator. Replace with explicit None check.