### PR TITLE
perf: prefetch workflow relations in incident list view

### DIFF
--- a/incidents/views.py
+++ b/incidents/views.py
@@ -196,7 +196,10 @@ def get_incidents(request):
     )
 
     f = IncidentFilter(incidents_filter_params, queryset=incidents)
-    incident_list = f.qs
+    incident_list = f.qs.prefetch_related(
+        "sector_regulation__workflows__sectorregulationworkflow_set",
+        "incidentworkflow_set__workflow__sectorregulationworkflow_set",
+    )
 
     per_page = incidents_filter_params.get("per_page", 10)
     page_number = incidents_filter_params.get("page")


### PR DESCRIPTION
Closes #712

## Problem
Per-incident calls to `get_workflows_completed()` and `get_all_workflows()` in the paginated list view caused N+1 queries — approximately 40–70 extra queries per page of 10 incidents.

## Fix
Add `prefetch_related("sector_regulation__workflows__sectorregulationworkflow_set", "incidentworkflow_set__workflow__sectorregulationworkflow_set")` to `f.qs` before pagination.