### PR TITLE
perf: prefetch answer/sector/impact relations in export_incidents

### DIFF
--- a/incidents/views.py
+++ b/incidents/views.py
@@ -785,6 +785,11 @@ def export_incidents(request):
                     sector_regulation__regulator__in=user.regulators.all(),
                     incident_notification_date__date__gte=from_date,
                     incident_notification_date__date__lte=to_date,
+                ).prefetch_related(
+                    "affected_sectors",
+                    "incidentworkflow_set__answer_set__question_options__question",
+                    "incidentworkflow_set__answer_set__predefined_answers",
+                    "incidentworkflow_set__impacts__sectors",
                 ).order_by("-incident_notification_date")
 
                 are_incidents = incidents.exists()


### PR DESCRIPTION
Closes #713

## Problem
Nested loops in `export_incidents` over `answer_set`, `predefined_answers`, and `impacts` generated O(incidents × answers × predefined_answers) queries.

## Fix
Add `prefetch_related` for `affected_sectors`, `incidentworkflow_set__answer_set__question_options__question`, `incidentworkflow_set__answer_set__predefined_answers`, and `incidentworkflow_set__impacts__sectors` on the RegulatorAdmin incidents queryset.