### PR TITLE
perf: prefetch children in get_sectors_grouped to eliminate N+1

### DIFF
--- a/governanceplatform/helpers.py
+++ b/governanceplatform/helpers.py
@@ -333,6 +333,7 @@ def filter_languages_not_translated(form):
 
 
 def get_sectors_grouped(sectors):
+    sectors = sectors.prefetch_related("children")
     categs = defaultdict(list)
     for sector in sectors:
         sector_name = sector.get_safe_translation()


### PR DESCRIPTION
Closes #717

## Problem
`sector.children.exists()` was called inside a Python loop over all sectors (invoked on every incident list request), firing one extra DB query per sector.

## Fix
Add `sectors = sectors.prefetch_related("children")` at function entry so `exists()` uses Django's prefetch cache (Django 4.1+).