### PR TITLE
fix: remove dead is_new_ticket assignment in create_or_update_rt_ticket

### DIFF
--- a/incidents/email.py
+++ b/incidents/email.py
@@ -190,9 +190,6 @@ def send_email(email, incident, send_to_observers=False):
 
 
 def create_or_update_rt_ticket(recipient, subject, content, incident):
-    is_new_ticket = not RTTicket.objects.filter(
-        incident=incident, observer=recipient
-    ).exists()
     base_url = recipient.rt_url.rstrip("/")
     try:
         validate_rt_url(base_url)


### PR DESCRIPTION
Closes #725

## Problem
Lines 193–195 computed `is_new_ticket` via `.exists()` but were immediately overwritten at line 211 via `.first()`. The first assignment and its extra DB query were dead code.

## Fix
Remove the initial `.exists()` call and its assignment.