### PR TITLE
refactor: replace f-strings in logger calls with %-style formatting

### DIFF
--- a/incidents/admin.py
+++ b/incidents/admin.py
@@ -367,7 +367,7 @@ def duplicate_objects(modeladmin, request, queryset):
                     request, f"Successfully duplicated {original_label} {model_name}"
                 )
         except Exception as e:
-            logger.exception(f"Error duplicating object {obj.pk}: {e}")
+            logger.exception("Error duplicating object %s: %s", obj.pk, e)
             messages.error(request, f"Error duplicating '{obj}': {str(e)}")
 
 

--- a/incidents/email.py
+++ b/incidents/email.py
@@ -197,7 +197,7 @@ def create_or_update_rt_ticket(recipient, subject, content, incident):
     try:
         validate_rt_url(base_url)
     except ValidationError:
-        logger.error(f"Blocked unsafe RT URL: {base_url}")
+        logger.error("Blocked unsafe RT URL: %s", base_url)
         return None
 
     headers = {
@@ -236,9 +236,9 @@ def create_or_update_rt_ticket(recipient, subject, content, incident):
                     ticket_id=ticket_data.get("id"),
                 )
         else:
-            logger.error(f"RT API Error {response.status_code}: {response.text}")
+            logger.error("RT API Error %s: %s", response.status_code, response.text)
     except requests.RequestException as e:
-        logger.error(f"Error connecting to RT API: {e}")
+        logger.error("Error connecting to RT API: %s", e)
 
 
 def check_rt_config(observer):
@@ -265,5 +265,5 @@ def check_rt_config(observer):
             )
         return False
     except requests.RequestException as e:
-        logger.error(f"Error connecting to RT API: {e}")
+        logger.error("Error connecting to RT API: %s", e)
         return False


### PR DESCRIPTION
Closes #723

## Problem
`logger.error(f"...")` eagerly evaluates the f-string even when the log level suppresses output, wasting CPU and preventing structured log templating.

## Fix
Replaced 4 calls in `incidents/email.py` and 1 in `incidents/admin.py` with `%`-style lazy formatting.