### PR TITLE
Fix for Suspicious unused loop iteration variable

### DIFF
--- a/incidents/forms.py
+++ b/incidents/forms.py
@@ -734,7 +734,7 @@ def get_forms_list(
             is_new_incident_workflow,
         )
 
-        for _category in categories:
+        for _ in categories:
             category_tree.append(QuestionForm)
 
         if workflow.is_impact_needed:


### PR DESCRIPTION
In general, when a loop variable is not used in the body, either remove the variable (e.g., rewrite as a range-based loop or a comprehension that does not bind it), or rename it to `_` to clearly indicate it is intentionally unused. This keeps the code’s behavior intact while making the author’s intent explicit and satisfying static analysis rules.

Here, the simplest, non‑functional change is to rename `_category` to `_` in the loop header. The body does not refer to `_category`, so this change does not affect runtime behavior. The only line that needs editing is the `for` statement around line 737 in `incidents/forms.py`, within the function that builds `category_tree`. No imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._