### PR TITLE
fix: complete UserSession session backend and extend test coverage

### DIFF
--- a/governanceplatform/models.py
+++ b/governanceplatform/models.py
@@ -696,6 +696,7 @@ class UserSession(AbstractBaseSession):
         blank=True,
         on_delete=models.CASCADE,
         related_name="sessions",
+        db_index=True,
     )
 
     @classmethod

--- a/governanceplatform/sessions.py
+++ b/governanceplatform/sessions.py
@@ -1,7 +1,6 @@
 from django.apps import apps
+from django.contrib.auth import SESSION_KEY as _SESSION_KEY
 from django.contrib.sessions.backends.db import SessionStore as DBStore
-
-_SESSION_KEY = "_auth_user_id"
 
 
 class SessionStore(DBStore):
@@ -9,11 +8,18 @@ class SessionStore(DBStore):
     def get_model_class(cls):
         return apps.get_model("governanceplatform", "UserSession")
 
+    def _extract_user_id(self, data):
+        try:
+            return int(data.get(_SESSION_KEY))
+        except (ValueError, TypeError):
+            return None
+
     def create_model_instance(self, data):
         obj = super().create_model_instance(data)
-        try:
-            user_id = int(data.get(_SESSION_KEY))
-        except (ValueError, TypeError):
-            user_id = None
-        obj.user_id = user_id
+        obj.user_id = self._extract_user_id(data)
+        return obj
+
+    async def acreate_model_instance(self, data):
+        obj = await super().acreate_model_instance(data)
+        obj.user_id = self._extract_user_id(data)
         return obj

--- a/governanceplatform/tests/test_session.py
+++ b/governanceplatform/tests/test_session.py
@@ -1,8 +1,10 @@
+import asyncio
 import hashlib
 import secrets
 from datetime import timedelta
 
 import pytest
+from django.db import transaction
 from django.utils.timezone import now
 
 from governanceplatform.models import User, UserSession
@@ -79,3 +81,72 @@ def test_session_store_leaves_user_id_null_for_anonymous():
     session = UserSession.objects.get(session_key=store.session_key)
     assert session.user_id is None
     store.delete()
+
+
+def test_extract_user_id_authenticated(simple_user):
+    store = SessionStore()
+    assert store._extract_user_id({"_auth_user_id": str(simple_user.pk)}) == simple_user.pk
+
+
+def test_extract_user_id_anonymous():
+    store = SessionStore()
+    assert store._extract_user_id({}) is None
+
+
+def test_extract_user_id_invalid():
+    store = SessionStore()
+    assert store._extract_user_id({"_auth_user_id": "not-a-number"}) is None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_force_logout_deferred_until_commit(simple_user):
+    session = _make_session(user=simple_user)
+
+    with transaction.atomic():
+        force_logout_user(simple_user)
+        # on_commit has not fired yet inside the atomic block
+        assert UserSession.objects.filter(session_key=session.session_key).exists()
+
+    # transaction committed — delete should have run
+    assert not UserSession.objects.filter(session_key=session.session_key).exists()
+
+
+@pytest.mark.django_db
+def test_user_delete_cascades_to_sessions(simple_user, other_user):
+    s1 = _make_session(user=simple_user)
+    s2 = _make_session(user=simple_user)
+    s_other = _make_session(user=other_user)
+
+    simple_user.delete()
+
+    assert not UserSession.objects.filter(session_key=s1.session_key).exists()
+    assert not UserSession.objects.filter(session_key=s2.session_key).exists()
+    assert UserSession.objects.filter(session_key=s_other.session_key).exists()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_async_session_store_sets_user_id(simple_user):
+    async def run():
+        store = SessionStore()
+        store["_auth_user_id"] = str(simple_user.pk)
+        await store.asave()
+        return store.session_key
+
+    session_key = asyncio.run(run())
+    session = UserSession.objects.get(session_key=session_key)
+    assert session.user_id == simple_user.pk
+    UserSession.objects.filter(session_key=session_key).delete()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_async_session_store_leaves_user_id_null_for_anonymous():
+    async def run():
+        store = SessionStore()
+        store["foo"] = "bar"
+        await store.asave()
+        return store.session_key
+
+    session_key = asyncio.run(run())
+    session = UserSession.objects.get(session_key=session_key)
+    assert session.user_id is None
+    UserSession.objects.filter(session_key=session_key).delete()


### PR DESCRIPTION
## Summary

Follow-up to #768 addressing issues found in code review.

- **Missing async path**: `acreate_model_instance` was absent from `sessions.py`, so Django's async session writes (ASGI views, `asave()`) never populated `user_id` — forced-logout silently had no effect for those sessions
- **Shared logic**: extracted `_extract_user_id` helper so both sync and async paths use identical coercion logic instead of duplicating it
- **Import hygiene**: replaced the hardcoded `_SESSION_KEY = "_auth_user_id"` string with `from django.contrib.auth import SESSION_KEY` to avoid drift from Django's own constant
- **Explicit index**: added `db_index=True` on `UserSession.user` FK to document that the `DELETE WHERE user_id=?` query in `force_logout_user` depends on this index (Django creates it by default for FK fields; no new migration needed)

## New tests

| Test | What it covers |
|---|---|
| `test_extract_user_id_authenticated` | user_id correctly parsed from session data |
| `test_extract_user_id_anonymous` | missing key → None |
| `test_extract_user_id_invalid` | non-integer value → None, not crash |
| `test_force_logout_deferred_until_commit` | `on_commit` does not fire mid-transaction; fires after commit |
| `test_user_delete_cascades_to_sessions` | deleting a User removes their sessions via CASCADE |
| `test_async_session_store_sets_user_id` | async `asave()` path sets `user_id` correctly |
| `test_async_session_store_leaves_user_id_null_for_anonymous` | async anonymous session → `user_id` is None |

## Testing

Full test suite run in CI. All new tests use real PostgreSQL (no mocks).