### PR TITLE
[NI][observer] Flag and filter incidents reported as cross-border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Unit tests for incident cleanup, log cleanup, workflow deadline notifications, and incident reminder scripts, helpers of governanceplatform
+- The observer incident list shows and filters incidents reported as having a cross-border impact, so a single point of contact can isolate the incidents that trigger a cross-border notification duty. The flag follows the most recent report answering the question, and stays inactive until a deployment names that question through the `cross_border_question_reference` application configuration key (#844)
 
 ### Changed
 

--- a/incidents/filters.py
+++ b/incidents/filters.py
@@ -51,3 +51,20 @@ class IncidentFilter(django_filters.FilterSet):
             | Q(sector_regulation__regulation__translations__label__icontains=value)
             | Q(affected_sectors__translations__name__icontains=value)
         ).distinct()
+
+
+class ObserverIncidentFilter(IncidentFilter):
+    """Incident filter for the observer role.
+
+    Observers act as the single point of contact of a Member State, so they
+    need to isolate the incidents reported as cross-border. The flag comes from
+    the ``is_cross_border_impact`` annotation, which the view adds.
+    """
+
+    cross_border_impact = django_filters.BooleanFilter(
+        field_name="is_cross_border_impact",
+        label=_("Cross-border impact"),
+    )
+
+    class Meta(IncidentFilter.Meta):
+        pass

--- a/incidents/helpers.py
+++ b/incidents/helpers.py
@@ -2,9 +2,81 @@ import math
 from collections import OrderedDict
 from itertools import chain
 
+from django.db.models import BooleanField, Exists, OuterRef, Subquery, Value
+from django.db.models.functions import Coalesce
 from django.utils import timezone
 
-from .models import Incident, IncidentWorkflow, QuestionCategory, QuestionCategoryOptions, SectorRegulationWorkflow, Workflow
+from governanceplatform.models import ApplicationConfig
+
+from .models import (
+    Answer,
+    Incident,
+    IncidentWorkflow,
+    PredefinedAnswer,
+    QuestionCategory,
+    QuestionCategoryOptions,
+    SectorRegulationWorkflow,
+    Workflow,
+)
+
+# Application config keys designating the question that carries the cross-border
+# dimension. The questionnaire is configuration, so the platform cannot know
+# which question that is: a deployment names it here.
+CROSS_BORDER_QUESTION_REFERENCE_KEY = "cross_border_question_reference"
+CROSS_BORDER_POSITIVE_ANSWER_KEY = "cross_border_positive_answer"
+DEFAULT_CROSS_BORDER_POSITIVE_ANSWER = "Yes"
+
+
+def get_application_config(key, default=None):
+    try:
+        return ApplicationConfig.objects.get(key=key).value
+    except ApplicationConfig.DoesNotExist:
+        return default
+
+
+def annotate_cross_border_impact(queryset):
+    """Annotate incidents with ``is_cross_border_impact``.
+
+    The flag reports the answer given in the most recent report answering the
+    designated question, so an incident that becomes cross-border in a later
+    report is picked up, and one that is corrected to "no" stops being flagged.
+
+    When no question is designated the annotation is ``False`` everywhere and
+    the queryset behaves exactly as before.
+    """
+    question_reference = get_application_config(CROSS_BORDER_QUESTION_REFERENCE_KEY)
+    if not question_reference:
+        return queryset.annotate(is_cross_border_impact=Value(False, output_field=BooleanField()))
+
+    positive_answer = get_application_config(
+        CROSS_BORDER_POSITIVE_ANSWER_KEY,
+        DEFAULT_CROSS_BORDER_POSITIVE_ANSWER,
+    )
+
+    latest_answer_is_positive = (
+        Answer.objects.filter(
+            incident_workflow__incident=OuterRef("pk"),
+            question_options__question__reference=question_reference,
+        )
+        .order_by("-incident_workflow__timestamp", "-timestamp")
+        .annotate(
+            is_positive=Exists(
+                PredefinedAnswer.objects.filter(
+                    answer__pk=OuterRef("pk"),
+                    translations__predefined_answer__iexact=positive_answer,
+                )
+            )
+        )
+        .values("is_positive")[:1]
+    )
+
+    return queryset.annotate(
+        is_cross_border_impact=Coalesce(
+            Subquery(latest_answer_is_positive, output_field=BooleanField()),
+            Value(False),
+            output_field=BooleanField(),
+        )
+    )
 
 
 def is_deadline_exceeded(report: Workflow, incident: Incident) -> str:

--- a/incidents/tests/test_cross_border.py
+++ b/incidents/tests/test_cross_border.py
@@ -1,10 +1,12 @@
 import datetime
 
 import pytest
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import activate
 
 from governanceplatform.models import ApplicationConfig
+from incidents.filters import ObserverIncidentFilter
 from incidents.helpers import (
     CROSS_BORDER_POSITIVE_ANSWER_KEY,
     CROSS_BORDER_QUESTION_REFERENCE_KEY,
@@ -146,3 +148,46 @@ def test_positive_answer_label_is_configurable(populate_incident_db):
     answer_cross_border(incident, "No", timezone.now())
 
     assert is_flagged(incident) is True
+
+
+@pytest.fixture
+def observer_client(otp_client, populate_incident_db):
+    """The seeded observer user, with the second factor satisfied."""
+    user = next(u for u in populate_incident_db["users"] if u.email == "obsadm@cert1.lu")
+    return otp_client(user)
+
+
+@pytest.mark.django_db
+def test_the_observer_list_view_carries_the_annotation(observer_client, populate_incident_db):
+    """The view is what wires the annotation and the filter to the observer role.
+
+    Covering the annotation alone leaves that wiring free to be rewritten from
+    under it, which is exactly what a refactor of the observer scoping does.
+    """
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, "Yes", timezone.now())
+
+    response = observer_client.get(reverse("incidents"))
+
+    assert response.status_code == 200
+    listed = {i.incident_id: i for i in response.context["incidents"].object_list}
+    assert incident.incident_id in listed
+    assert listed[incident.incident_id].is_cross_border_impact is True
+    assert isinstance(response.context["filter"], ObserverIncidentFilter)
+
+
+@pytest.mark.django_db
+def test_the_observer_list_view_can_filter_on_it(observer_client, populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    flagged, plain = populate_incident_db["incidents"][0], populate_incident_db["incidents"][1]
+    answer_cross_border(flagged, "Yes", timezone.now())
+    answer_cross_border(plain, "No", timezone.now())
+
+    response = observer_client.get(reverse("incidents"), {"cross_border_impact": "true"})
+
+    listed = {i.incident_id for i in response.context["incidents"].object_list}
+    assert flagged.incident_id in listed
+    assert plain.incident_id not in listed

--- a/incidents/tests/test_cross_border.py
+++ b/incidents/tests/test_cross_border.py
@@ -1,0 +1,148 @@
+import datetime
+
+import pytest
+from django.utils import timezone
+from django.utils.translation import activate
+
+from governanceplatform.models import ApplicationConfig
+from incidents.helpers import (
+    CROSS_BORDER_POSITIVE_ANSWER_KEY,
+    CROSS_BORDER_QUESTION_REFERENCE_KEY,
+    annotate_cross_border_impact,
+)
+from incidents.models import (
+    Answer,
+    Incident,
+    IncidentWorkflow,
+    PredefinedAnswer,
+    QuestionOptions,
+    Workflow,
+)
+
+CROSS_BORDER_QUESTION_REFERENCE = "1"
+
+
+def designate_cross_border_question(positive_answer=None):
+    ApplicationConfig.objects.create(
+        key=CROSS_BORDER_QUESTION_REFERENCE_KEY,
+        value=CROSS_BORDER_QUESTION_REFERENCE,
+    )
+    if positive_answer is not None:
+        ApplicationConfig.objects.create(
+            key=CROSS_BORDER_POSITIVE_ANSWER_KEY,
+            value=positive_answer,
+        )
+
+
+def answer_cross_border(incident, predefined_answer_label, submitted_at):
+    """Submit a report answering the cross-border question."""
+    question_options = QuestionOptions.objects.filter(question__reference=CROSS_BORDER_QUESTION_REFERENCE).first()
+    incident_workflow = IncidentWorkflow.objects.create(
+        incident=incident,
+        workflow=Workflow.objects.first(),
+        timestamp=submitted_at,
+    )
+    answer = Answer.objects.create(
+        incident_workflow=incident_workflow,
+        question_options=question_options,
+        timestamp=submitted_at,
+    )
+    answer.predefined_answers.set(
+        PredefinedAnswer.objects.filter(
+            question=question_options.question,
+            translations__predefined_answer=predefined_answer_label,
+        )
+    )
+    return incident_workflow
+
+
+def is_flagged(incident):
+    return annotate_cross_border_impact(Incident.objects.filter(pk=incident.pk)).first().is_cross_border_impact
+
+
+@pytest.mark.django_db
+def test_no_designated_question_flags_nothing(populate_incident_db):
+    """Without an application config, every incident reads as not cross-border."""
+    activate("en")
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, "Yes", timezone.now())
+
+    assert is_flagged(incident) is False
+
+
+@pytest.mark.django_db
+def test_positive_answer_is_flagged(populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, "Yes", timezone.now())
+
+    assert is_flagged(incident) is True
+
+
+@pytest.mark.django_db
+def test_negative_answer_is_not_flagged(populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, "No", timezone.now())
+
+    assert is_flagged(incident) is False
+
+
+@pytest.mark.django_db
+def test_incident_without_answer_is_not_flagged(populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+
+    assert is_flagged(incident) is False
+
+
+@pytest.mark.django_db
+def test_latest_report_wins(populate_incident_db):
+    """A later report correcting the answer to "no" clears the flag."""
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    early_warning = timezone.now() - datetime.timedelta(days=2)
+    answer_cross_border(incident, "Yes", early_warning)
+    assert is_flagged(incident) is True
+
+    answer_cross_border(incident, "No", timezone.now())
+    assert is_flagged(incident) is False
+
+
+@pytest.mark.django_db
+def test_later_report_raises_the_flag(populate_incident_db):
+    """An incident that turns out to be cross-border later is picked up."""
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, "No", timezone.now() - datetime.timedelta(days=2))
+    assert is_flagged(incident) is False
+
+    answer_cross_border(incident, "Yes", timezone.now())
+    assert is_flagged(incident) is True
+
+
+@pytest.mark.django_db
+def test_other_incidents_are_untouched(populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    flagged_incident, other_incident = populate_incident_db["incidents"][:2]
+    answer_cross_border(flagged_incident, "Yes", timezone.now())
+
+    assert is_flagged(flagged_incident) is True
+    assert is_flagged(other_incident) is False
+
+
+@pytest.mark.django_db
+def test_positive_answer_label_is_configurable(populate_incident_db):
+    """A deployment whose questionnaire says "Oui" configures it."""
+    activate("en")
+    designate_cross_border_question(positive_answer="No")
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, "No", timezone.now())
+
+    assert is_flagged(incident) is True

--- a/incidents/views.py
+++ b/incidents/views.py
@@ -62,7 +62,7 @@ from .access_control import (
     get_observer_incidents,
 )
 from .email import send_email, send_html_email
-from .filters import IncidentFilter
+from .filters import IncidentFilter, ObserverIncidentFilter
 from .forms import ContactForm, ExportIncidentsForm, IncidentStatusForm, RegulatorIncidentWorkflowCommentForm, get_forms_list
 from .globals import (
     ALLOWED_SORT_FIELDS,
@@ -70,7 +70,11 @@ from .globals import (
     REPORT_STATUS_MAP,
     WORKFLOW_REVIEW_STATUS,
 )
-from .helpers import get_workflow_categories, is_deadline_exceeded
+from .helpers import (
+    annotate_cross_border_impact,
+    get_workflow_categories,
+    is_deadline_exceeded,
+)
 from .models import (
     Answer,
     Impact,
@@ -145,7 +149,7 @@ def get_incidents(request):
             incidents = incidents.filter(sector_regulation__regulator__in=user.regulators.all())
     elif is_observer_user(user):
         html_view = "observer/incidents.html"
-        incidents = get_observer_incidents(user.observers.first())
+        incidents = annotate_cross_border_impact(get_observer_incidents(user.observers.first()))
     elif is_user_operator(user):
         # OperatorAdmin/User can see all the reports of the selected company.
         incidents = incidents.filter(
@@ -205,7 +209,8 @@ def get_incidents(request):
         ALLOWED_SORT_FIELDS,
     )
 
-    f = IncidentFilter(incidents_filter_params, queryset=incidents)
+    filter_class = ObserverIncidentFilter if is_observer_user(user) else IncidentFilter
+    f = filter_class(incidents_filter_params, queryset=incidents)
     incident_list = f.qs.prefetch_related(
         "sector_regulation__workflows__sectorregulationworkflow_set",
         "incidentworkflow_set__workflow__sectorregulationworkflow_set",

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -891,6 +891,10 @@ msgstr ""
 msgid "Search"
 msgstr "Suchen"
 
+#: incidents/filters.py:66
+msgid "Cross-border impact"
+msgstr "Grenzüberschreitende Auswirkungen"
+
 #: incidents/forms.py:246 incidents/forms.py:403
 msgid "Add details"
 msgstr "Details hinzufügen"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -888,6 +888,10 @@ msgstr ""
 msgid "Search"
 msgstr "Rechercher"
 
+#: incidents/filters.py:66
+msgid "Cross-border impact"
+msgstr "Impact transfrontalier"
+
 #: incidents/forms.py:246 incidents/forms.py:403
 msgid "Add details"
 msgstr "Ajouter des précisions"

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -880,6 +880,10 @@ msgstr ""
 msgid "Search"
 msgstr "Zoeken"
 
+#: incidents/filters.py:66
+msgid "Cross-border impact"
+msgstr "Grensoverschrijdende impact"
+
 #: incidents/forms.py:246 incidents/forms.py:403
 msgid "Add details"
 msgstr "Voeg details toe"


### PR DESCRIPTION
Closes #844.

## What it does

Adds an `is_cross_border_impact` annotation to the incident queryset of the observer role, and a filter on it. An observer can now see at a glance which incidents were reported as affecting more than one Member State, which is the trigger of the Article 23(6) obligation the single point of contact has to act on. The rationale is in #844.

## It does nothing until an instance configures it

Two keys are read from `ApplicationConfig`, the key/value store already used for the cookie banner:

| Key | Meaning |
|---|---|
| `cross_border_question_reference` | the `reference` of the question carrying the cross-border dimension |
| `cross_border_positive_answer` | the predefined answer that counts as positive; defaults to `Yes` |

Without the first key the annotation is `False` for every incident and the queryset behaves exactly as before. No migration, and no change to any existing deployment that does not opt in.

## Semantics

The flag reflects the answer given in the **most recent** report that answers the designated question. An incident that becomes cross-border in a later report starts being flagged; one corrected to "no" stops. This is the same behaviour as `is_significative_impact`, which `save_answers()` overwrites on each submission.

Answers other than the configured positive one — including a third "uncertain" modality where the national form offers it — do not raise the flag. That is a deliberate simplification for a first version and is easy to revisit.

## Scope

The annotation and the filter are applied in the observer branch of the view only. Operator and regulator paths are untouched, and neither the annotation nor its subquery is added to their querysets.

## Changes

- `incidents/helpers.py` — `annotate_cross_border_impact()` and a small `ApplicationConfig` reader
- `incidents/filters.py` — `ObserverIncidentFilter`, subclassing `IncidentFilter`
- `incidents/views.py` — annotate in the observer branch, pick the filter class by role
- `incidents/tests/test_cross_border.py` — 10 tests
- `locale/{fr,de,nl}` — the new filter label

The templates live in `default-theme`, so a companion pull request is needed for anything to be visible: informed-governance-project/default-theme#10.

## Testing

Eight tests cover the annotation: the unconfigured case, a positive and a negative answer, an incident with no answer at all, both directions of the "latest report wins" rule, isolation between incidents, and a configurable positive label.

Two more go through the view, and they were added after this branch was rebased. Moving the observer scoping into `incidents/access_control.py` rewrote the very line that wires the annotation to the observer role, and nothing here would have failed had it been rewritten without it. They assert that the listed incidents carry the flag, that the filter class in use is the observer one, and that filtering on it selects correctly.

The full suite passes, and `ruff format --check` and `ruff check` are clean.

Beyond unit tests, the change was exercised in a local instance seeded with nine incidents across five entities and four sectors, including one declared cross-border at the early warning and corrected in the final report, and one that only becomes cross-border in the second report. The observer list flagged three of the nine, the filter returned the same three, and the regulator view rendered without the badge or the filter field.

**Rebased onto `dev`** after the `#853` refactor: `Observer.get_incidents()` became `get_observer_incidents(observer)` and still returns a queryset, so the annotation attaches unchanged.

## Happy to rework

If you would rather have this as a field on `Incident`, or expressed through `ObserverRegulation.incident_rule` so that observers can also be scoped and notified on answers, say the word. The current shape was chosen to avoid a schema change, since `AGENTS.md` asks for those to be discussed first.

