### PR TITLE
[NI][email] Add a #CROSS_BORDER# placeholder to notification templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Unit tests for incident cleanup, log cleanup, workflow deadline notifications, and incident reminder scripts, helpers of governanceplatform
 - The observer incident list shows and filters incidents reported as having a cross-border impact, so a single point of contact can isolate the incidents that trigger a cross-border notification duty. The flag follows the most recent report answering the question, and stays inactive until a deployment names that question through the `cross_border_question_reference` application configuration key (#844)
+- A `#CROSS_BORDER#` placeholder is available in notification subjects and contents. It renders a marker when the incident is reported as having a cross-border impact and nothing otherwise, so a regulator can make the distinction visible in the mailbox rather than only in the incident list. Templates that do not carry the placeholder are unchanged (#846)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Unit tests for incident cleanup, log cleanup, workflow deadline notifications, and incident reminder scripts, helpers of governanceplatform
+- The observer incident list shows and filters incidents reported as having a cross-border impact, so a single point of contact can isolate the incidents that trigger a cross-border notification duty. The flag follows the most recent report answering the question, and stays inactive until a deployment names that question through the `cross_border_question_reference` application configuration key (#844)
 
 ### Changed
 

--- a/incidents/email.py
+++ b/incidents/email.py
@@ -3,7 +3,8 @@ from datetime import date
 
 from django.conf import settings
 from django.urls import reverse
-from django.utils import timezone
+from django.utils import timezone, translation
+from django.utils.translation import gettext
 
 from governanceplatform.email import send_html_email
 from governanceplatform.helpers import render_to_string_multi_languages
@@ -12,6 +13,7 @@ from governanceplatform.rt import add_rt_correspondence, check_rt_config, create
 from incidents.globals import INCIDENT_EMAIL_VARIABLES
 
 from .access_control import observer_can_access_incident
+from .helpers import is_cross_border_incident
 from .models import RTTicket
 
 logger = logging.getLogger(__name__)
@@ -53,6 +55,12 @@ def replace_email_variables(content, incident):
             else:
                 deadline = timezone.localtime(deadline)
                 var_txt = deadline.strftime("%Y-%m-%d %H:%M %Z")
+        elif variable == "#CROSS_BORDER#":
+            # A marker rather than a value: it either marks the message or adds
+            # nothing at all, so a template carrying it reads correctly in both
+            # cases. Rendered in the language active for the section being
+            # written, like every other translated string in the body.
+            var_txt = f"[{gettext('Cross-border')}]" if is_cross_border_incident(incident) else ""
         else:
             var_txt = getattr(incident, key) if getattr(incident, key) is not None else ""
             if isinstance(var_txt, date):
@@ -103,10 +111,20 @@ def get_recipient_list(incident):
 
 
 def send_email(email, incident, send_to_observers=False):
-    subject = replace_email_variables(
-        email.safe_translation_getter("subject", language_code=settings.LANGUAGE_CODE),
-        incident,
-    )
+    # The subject text is taken in the instance language, so what is substituted
+    # into it follows the same language. Left to the ambient one, a translated
+    # placeholder would render in the language of whoever triggered the send and
+    # mix two languages inside a single subject line.
+    with translation.override(settings.LANGUAGE_CODE):
+        subject = replace_email_variables(
+            email.safe_translation_getter("subject", language_code=settings.LANGUAGE_CODE),
+            incident,
+        )
+    # A placeholder that renders empty leaves the spacing its template author
+    # wrote around it, which shows up in the mailbox as a subject starting with
+    # a space or carrying a double one. Harmless in a body, visible in a subject
+    # line, and routine now that a placeholder is empty by design half the time.
+    subject = " ".join(subject.split())
     html_content = render_to_string_multi_languages(
         "incidents/email.html",
         {

--- a/incidents/filters.py
+++ b/incidents/filters.py
@@ -51,3 +51,20 @@ class IncidentFilter(django_filters.FilterSet):
             | Q(sector_regulation__regulation__translations__label__icontains=value)
             | Q(affected_sectors__translations__name__icontains=value)
         ).distinct()
+
+
+class ObserverIncidentFilter(IncidentFilter):
+    """Incident filter for the observer role.
+
+    Observers act as the single point of contact of a Member State, so they
+    need to isolate the incidents reported as cross-border. The flag comes from
+    the ``is_cross_border_impact`` annotation, which the view adds.
+    """
+
+    cross_border_impact = django_filters.BooleanFilter(
+        field_name="is_cross_border_impact",
+        label=_("Cross-border impact"),
+    )
+
+    class Meta(IncidentFilter.Meta):
+        pass

--- a/incidents/globals.py
+++ b/incidents/globals.py
@@ -27,6 +27,7 @@ INCIDENT_EMAIL_VARIABLES = [
     ("#INCIDENT_STARTING_DATE#", "incident_starting_date"),
     ("#INCIDENT_ID#", "incident_id"),
     ("#DEADLINE#", "get_deadline"),
+    ("#CROSS_BORDER#", "is_cross_border_impact"),
 ]
 
 # the different trigger on when to send an email to the Incident.User

--- a/incidents/helpers.py
+++ b/incidents/helpers.py
@@ -2,9 +2,81 @@ import math
 from collections import OrderedDict
 from itertools import chain
 
+from django.db.models import BooleanField, Exists, OuterRef, Subquery, Value
+from django.db.models.functions import Coalesce
 from django.utils import timezone
 
-from .models import Incident, IncidentWorkflow, QuestionCategory, QuestionCategoryOptions, SectorRegulationWorkflow, Workflow
+from governanceplatform.models import ApplicationConfig
+
+from .models import (
+    Answer,
+    Incident,
+    IncidentWorkflow,
+    PredefinedAnswer,
+    QuestionCategory,
+    QuestionCategoryOptions,
+    SectorRegulationWorkflow,
+    Workflow,
+)
+
+# Application config keys designating the question that carries the cross-border
+# dimension. The questionnaire is configuration, so the platform cannot know
+# which question that is: a deployment names it here.
+CROSS_BORDER_QUESTION_REFERENCE_KEY = "cross_border_question_reference"
+CROSS_BORDER_POSITIVE_ANSWER_KEY = "cross_border_positive_answer"
+DEFAULT_CROSS_BORDER_POSITIVE_ANSWER = "Yes"
+
+
+def get_application_config(key, default=None):
+    try:
+        return ApplicationConfig.objects.get(key=key).value
+    except ApplicationConfig.DoesNotExist:
+        return default
+
+
+def annotate_cross_border_impact(queryset):
+    """Annotate incidents with ``is_cross_border_impact``.
+
+    The flag reports the answer given in the most recent report answering the
+    designated question, so an incident that becomes cross-border in a later
+    report is picked up, and one that is corrected to "no" stops being flagged.
+
+    When no question is designated the annotation is ``False`` everywhere and
+    the queryset behaves exactly as before.
+    """
+    question_reference = get_application_config(CROSS_BORDER_QUESTION_REFERENCE_KEY)
+    if not question_reference:
+        return queryset.annotate(is_cross_border_impact=Value(False, output_field=BooleanField()))
+
+    positive_answer = get_application_config(
+        CROSS_BORDER_POSITIVE_ANSWER_KEY,
+        DEFAULT_CROSS_BORDER_POSITIVE_ANSWER,
+    )
+
+    latest_answer_is_positive = (
+        Answer.objects.filter(
+            incident_workflow__incident=OuterRef("pk"),
+            question_options__question__reference=question_reference,
+        )
+        .order_by("-incident_workflow__timestamp", "-timestamp")
+        .annotate(
+            is_positive=Exists(
+                PredefinedAnswer.objects.filter(
+                    answer__pk=OuterRef("pk"),
+                    translations__predefined_answer__iexact=positive_answer,
+                )
+            )
+        )
+        .values("is_positive")[:1]
+    )
+
+    return queryset.annotate(
+        is_cross_border_impact=Coalesce(
+            Subquery(latest_answer_is_positive, output_field=BooleanField()),
+            Value(False),
+            output_field=BooleanField(),
+        )
+    )
 
 
 def is_deadline_exceeded(report: Workflow, incident: Incident) -> str:

--- a/incidents/helpers.py
+++ b/incidents/helpers.py
@@ -79,6 +79,17 @@ def annotate_cross_border_impact(queryset):
     )
 
 
+def is_cross_border_incident(incident: Incident) -> bool:
+    """Whether this single incident is currently reported as cross-border.
+
+    Same rule as :func:`annotate_cross_border_impact`, for the one caller that
+    holds an incident rather than a queryset. Returns ``False`` when no question
+    is designated, so callers need no special case.
+    """
+    annotated = annotate_cross_border_impact(Incident.objects.filter(pk=incident.pk))
+    return annotated.values_list("is_cross_border_impact", flat=True).first() or False
+
+
 def is_deadline_exceeded(report: Workflow, incident: Incident) -> str:
     latest_incident_workflow = incident.get_latest_incident_workflow_by_workflow(report)
     if latest_incident_workflow is not None:

--- a/incidents/tests/test_cross_border.py
+++ b/incidents/tests/test_cross_border.py
@@ -1,10 +1,12 @@
 import datetime
 
 import pytest
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import activate
 
 from governanceplatform.models import ApplicationConfig
+from incidents.filters import ObserverIncidentFilter
 from incidents.helpers import (
     CROSS_BORDER_POSITIVE_ANSWER_KEY,
     CROSS_BORDER_QUESTION_REFERENCE_KEY,
@@ -146,3 +148,46 @@ def test_positive_answer_label_is_configurable(populate_incident_db):
     answer_cross_border(incident, "No", timezone.now())
 
     assert is_flagged(incident) is True
+
+
+@pytest.fixture
+def observer_client(otp_client, populate_incident_db):
+    """The seeded observer user, with the second factor satisfied."""
+    user = next(u for u in populate_incident_db["users"] if u.email == "obsadm@cert1.lu")
+    return otp_client(user)
+
+
+@pytest.mark.django_db
+def test_the_observer_list_view_carries_the_annotation(observer_client, populate_incident_db):
+    """The view is what wires the annotation and the filter to the observer role.
+
+    Covering the annotation alone leaves that wiring free to be rewritten from
+    under it, which is exactly what a refactor of the observer scoping does.
+    """
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, "Yes", timezone.now())
+
+    response = observer_client.get(reverse("incidents"))
+
+    assert response.status_code == 200
+    listed = {i.incident_id: i for i in response.context["incidents"].object_list}
+    assert incident.incident_id in listed
+    assert listed[incident.incident_id].is_cross_border_impact is True
+    assert isinstance(response.context["filter"], ObserverIncidentFilter)
+
+
+@pytest.mark.django_db
+def test_the_observer_list_view_can_filter_on_it(observer_client, populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    flagged, plain = populate_incident_db["incidents"][0], populate_incident_db["incidents"][1]
+    answer_cross_border(flagged, "Yes", timezone.now())
+    answer_cross_border(plain, "No", timezone.now())
+
+    response = observer_client.get(reverse("incidents"), {"cross_border_impact": "true"})
+
+    listed = {i.incident_id for i in response.context["incidents"].object_list}
+    assert flagged.incident_id in listed
+    assert plain.incident_id not in listed

--- a/incidents/tests/test_cross_border.py
+++ b/incidents/tests/test_cross_border.py
@@ -18,6 +18,7 @@ from incidents.models import (
     IncidentWorkflow,
     PredefinedAnswer,
     QuestionOptions,
+    ReportTimeline,
     Workflow,
 )
 
@@ -43,6 +44,10 @@ def answer_cross_border(incident, predefined_answer_label, submitted_at):
         incident=incident,
         workflow=Workflow.objects.first(),
         timestamp=submitted_at,
+        # save_answers() always creates one, and replace_email_variables()
+        # dereferences it, so a report without a timeline is not a realistic
+        # fixture.
+        report_timeline=ReportTimeline.objects.create(incident_detection_date=submitted_at),
     )
     answer = Answer.objects.create(
         incident_workflow=incident_workflow,

--- a/incidents/tests/test_cross_border.py
+++ b/incidents/tests/test_cross_border.py
@@ -1,0 +1,148 @@
+import datetime
+
+import pytest
+from django.utils import timezone
+from django.utils.translation import activate
+
+from governanceplatform.models import ApplicationConfig
+from incidents.helpers import (
+    CROSS_BORDER_POSITIVE_ANSWER_KEY,
+    CROSS_BORDER_QUESTION_REFERENCE_KEY,
+    annotate_cross_border_impact,
+)
+from incidents.models import (
+    Answer,
+    Incident,
+    IncidentWorkflow,
+    PredefinedAnswer,
+    QuestionOptions,
+    Workflow,
+)
+
+CROSS_BORDER_QUESTION_REFERENCE = "1"
+
+
+def designate_cross_border_question(positive_answer=None):
+    ApplicationConfig.objects.create(
+        key=CROSS_BORDER_QUESTION_REFERENCE_KEY,
+        value=CROSS_BORDER_QUESTION_REFERENCE,
+    )
+    if positive_answer is not None:
+        ApplicationConfig.objects.create(
+            key=CROSS_BORDER_POSITIVE_ANSWER_KEY,
+            value=positive_answer,
+        )
+
+
+def answer_cross_border(incident, predefined_answer_label, submitted_at):
+    """Submit a report answering the cross-border question."""
+    question_options = QuestionOptions.objects.filter(question__reference=CROSS_BORDER_QUESTION_REFERENCE).first()
+    incident_workflow = IncidentWorkflow.objects.create(
+        incident=incident,
+        workflow=Workflow.objects.first(),
+        timestamp=submitted_at,
+    )
+    answer = Answer.objects.create(
+        incident_workflow=incident_workflow,
+        question_options=question_options,
+        timestamp=submitted_at,
+    )
+    answer.predefined_answers.set(
+        PredefinedAnswer.objects.filter(
+            question=question_options.question,
+            translations__predefined_answer=predefined_answer_label,
+        )
+    )
+    return incident_workflow
+
+
+def is_flagged(incident):
+    return annotate_cross_border_impact(Incident.objects.filter(pk=incident.pk)).first().is_cross_border_impact
+
+
+@pytest.mark.django_db
+def test_no_designated_question_flags_nothing(populate_incident_db):
+    """Without an application config, every incident reads as not cross-border."""
+    activate("en")
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, "Yes", timezone.now())
+
+    assert is_flagged(incident) is False
+
+
+@pytest.mark.django_db
+def test_positive_answer_is_flagged(populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, "Yes", timezone.now())
+
+    assert is_flagged(incident) is True
+
+
+@pytest.mark.django_db
+def test_negative_answer_is_not_flagged(populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, "No", timezone.now())
+
+    assert is_flagged(incident) is False
+
+
+@pytest.mark.django_db
+def test_incident_without_answer_is_not_flagged(populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+
+    assert is_flagged(incident) is False
+
+
+@pytest.mark.django_db
+def test_latest_report_wins(populate_incident_db):
+    """A later report correcting the answer to "no" clears the flag."""
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    early_warning = timezone.now() - datetime.timedelta(days=2)
+    answer_cross_border(incident, "Yes", early_warning)
+    assert is_flagged(incident) is True
+
+    answer_cross_border(incident, "No", timezone.now())
+    assert is_flagged(incident) is False
+
+
+@pytest.mark.django_db
+def test_later_report_raises_the_flag(populate_incident_db):
+    """An incident that turns out to be cross-border later is picked up."""
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, "No", timezone.now() - datetime.timedelta(days=2))
+    assert is_flagged(incident) is False
+
+    answer_cross_border(incident, "Yes", timezone.now())
+    assert is_flagged(incident) is True
+
+
+@pytest.mark.django_db
+def test_other_incidents_are_untouched(populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    flagged_incident, other_incident = populate_incident_db["incidents"][:2]
+    answer_cross_border(flagged_incident, "Yes", timezone.now())
+
+    assert is_flagged(flagged_incident) is True
+    assert is_flagged(other_incident) is False
+
+
+@pytest.mark.django_db
+def test_positive_answer_label_is_configurable(populate_incident_db):
+    """A deployment whose questionnaire says "Oui" configures it."""
+    activate("en")
+    designate_cross_border_question(positive_answer="No")
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, "No", timezone.now())
+
+    assert is_flagged(incident) is True

--- a/incidents/tests/test_cross_border_email.py
+++ b/incidents/tests/test_cross_border_email.py
@@ -1,0 +1,179 @@
+import datetime
+
+import pytest
+from django.core import mail
+from django.test import override_settings
+from django.utils import timezone
+from django.utils.translation import activate
+
+from incidents.email import send_email
+from incidents.models import Email
+from incidents.tests.test_cross_border import (
+    answer_cross_border,
+    designate_cross_border_question,
+)
+
+MARKER = "[Cross-border]"
+ANSWER_YES = "Yes"
+ANSWER_NO = "No"
+
+
+def prepare_email(subject="Report submitted for #INCIDENT_ID#", content="A report was submitted."):
+    """Reuse a fixture email.
+
+    The fixtures insert emails with explicit primary keys without advancing the
+    sequence, so creating one here collides on the id.
+    """
+    email = Email.objects.first()
+    email.set_current_language("en")
+    email.subject = subject
+    email.content = content
+    email.save()
+    return email
+
+
+def send(incident, subject="#CROSS_BORDER# Report submitted for #INCIDENT_ID#", content="A report was submitted."):
+    mail.outbox = []
+    send_email(prepare_email(subject, content), incident, send_to_observers=True)
+    return mail.outbox[0]
+
+
+@pytest.mark.django_db
+def test_placeholder_renders_nothing_without_a_designated_question(populate_incident_db):
+    """An instance that has configured nothing sees no marker."""
+    activate("en")
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, ANSWER_YES, timezone.now())
+
+    assert MARKER not in send(incident).subject
+
+
+@pytest.mark.django_db
+def test_placeholder_is_left_alone_in_an_untouched_template(populate_incident_db):
+    """A regulator who does not ask for the marker sees the subject unchanged.
+
+    This is the difference with marking every message automatically: the
+    platform adds nothing to a template that does not carry the placeholder.
+    """
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, ANSWER_YES, timezone.now())
+
+    message = send(incident, subject="Report submitted for #INCIDENT_ID#")
+
+    assert MARKER not in message.subject
+    assert message.subject.startswith("Report submitted for ")
+
+
+@pytest.mark.django_db
+def test_cross_border_incident_is_marked_in_the_subject(populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, ANSWER_YES, timezone.now())
+
+    assert send(incident).subject.startswith(MARKER)
+
+
+@pytest.mark.django_db
+def test_cross_border_incident_is_marked_in_the_body(populate_incident_db):
+    """The same placeholder works in the content, not only in the subject."""
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, ANSWER_YES, timezone.now())
+
+    message = send(incident, content="A report was submitted. #CROSS_BORDER#")
+
+    assert MARKER in message.body
+
+
+@pytest.mark.django_db
+def test_other_incidents_render_an_empty_marker(populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, ANSWER_NO, timezone.now())
+
+    assert MARKER not in send(incident).subject
+
+
+@pytest.mark.django_db
+def test_incident_without_any_report_renders_an_empty_marker(populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+
+    assert MARKER not in send(incident).subject
+
+
+@pytest.mark.django_db
+def test_latest_report_decides(populate_incident_db):
+    """A final report correcting the answer to "no" removes the marker."""
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, ANSWER_YES, timezone.now() - datetime.timedelta(days=2))
+    assert send(incident).subject.startswith(MARKER)
+
+    answer_cross_border(incident, ANSWER_NO, timezone.now())
+    assert MARKER not in send(incident).subject
+
+
+@pytest.mark.django_db
+def test_late_switch_to_cross_border_is_picked_up(populate_incident_db):
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, ANSWER_NO, timezone.now() - datetime.timedelta(days=2))
+    assert MARKER not in send(incident).subject
+
+    answer_cross_border(incident, ANSWER_YES, timezone.now())
+    assert send(incident).subject.startswith(MARKER)
+
+
+@pytest.mark.django_db
+@override_settings(LANGUAGE_CODE="fr")
+def test_subject_marker_follows_the_instance_language(populate_incident_db):
+    """The subject is taken in the instance language; the marker follows it.
+
+    The language active when the send is triggered is deliberately a different
+    one, which is what happens when an operator submits a report in English on
+    a French instance.
+    """
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, ANSWER_YES, timezone.now())
+
+    assert send(incident).subject.startswith("[Transfrontalier]")
+
+
+@pytest.mark.django_db
+def test_empty_marker_leaves_no_spacing_artefact(populate_incident_db):
+    """An empty placeholder must not leave the space its template wrote around it."""
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+    answer_cross_border(incident, ANSWER_NO, timezone.now())
+
+    subject = send(incident).subject
+
+    assert subject == subject.strip()
+    assert "  " not in subject
+
+
+@pytest.mark.django_db
+def test_recipients_are_unchanged(populate_incident_db):
+    """The marker is text; it must not move anybody in or out."""
+    activate("en")
+    designate_cross_border_question()
+    incident = populate_incident_db["incidents"][0]
+
+    before = send(incident).bcc
+
+    answer_cross_border(incident, ANSWER_YES, timezone.now())
+    after = send(incident).bcc
+
+    assert before == after

--- a/incidents/views.py
+++ b/incidents/views.py
@@ -62,7 +62,7 @@ from .access_control import (
     get_observer_incidents,
 )
 from .email import send_email, send_html_email
-from .filters import IncidentFilter
+from .filters import IncidentFilter, ObserverIncidentFilter
 from .forms import ContactForm, ExportIncidentsForm, IncidentStatusForm, RegulatorIncidentWorkflowCommentForm, get_forms_list
 from .globals import (
     ALLOWED_SORT_FIELDS,
@@ -70,7 +70,11 @@ from .globals import (
     REPORT_STATUS_MAP,
     WORKFLOW_REVIEW_STATUS,
 )
-from .helpers import get_workflow_categories, is_deadline_exceeded
+from .helpers import (
+    annotate_cross_border_impact,
+    get_workflow_categories,
+    is_deadline_exceeded,
+)
 from .models import (
     Answer,
     Impact,
@@ -145,7 +149,7 @@ def get_incidents(request):
             incidents = incidents.filter(sector_regulation__regulator__in=user.regulators.all())
     elif is_observer_user(user):
         html_view = "observer/incidents.html"
-        incidents = get_observer_incidents(user.observers.first())
+        incidents = annotate_cross_border_impact(get_observer_incidents(user.observers.first()))
     elif is_user_operator(user):
         # OperatorAdmin/User can see all the reports of the selected company.
         incidents = incidents.filter(
@@ -205,7 +209,8 @@ def get_incidents(request):
         ALLOWED_SORT_FIELDS,
     )
 
-    f = IncidentFilter(incidents_filter_params, queryset=incidents)
+    filter_class = ObserverIncidentFilter if is_observer_user(user) else IncidentFilter
+    f = filter_class(incidents_filter_params, queryset=incidents)
     incident_list = f.qs.prefetch_related(
         "sector_regulation__workflows__sectorregulationworkflow_set",
         "incidentworkflow_set__workflow__sectorregulationworkflow_set",

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -891,6 +891,10 @@ msgstr ""
 msgid "Search"
 msgstr "Suchen"
 
+#: incidents/filters.py:66
+msgid "Cross-border impact"
+msgstr "Grenzüberschreitende Auswirkungen"
+
 #: incidents/forms.py:246 incidents/forms.py:403
 msgid "Add details"
 msgstr "Details hinzufügen"

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -887,6 +887,10 @@ msgstr ""
 "Dem Benutzerkonto sind derzeit keine Entitäten zugeordnet. Bitte wenden Sie "
 "sich an den Administrator."
 
+#: incidents/email.py:75
+msgid "Cross-border"
+msgstr "Grenzüberschreitend"
+
 #: incidents/filters.py:22
 msgid "Search"
 msgstr "Suchen"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -888,6 +888,10 @@ msgstr ""
 msgid "Search"
 msgstr "Rechercher"
 
+#: incidents/filters.py:66
+msgid "Cross-border impact"
+msgstr "Impact transfrontalier"
+
 #: incidents/forms.py:246 incidents/forms.py:403
 msgid "Add details"
 msgstr "Ajouter des précisions"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -884,6 +884,10 @@ msgstr ""
 "Le compte d'utilisateur n'a actuellement aucune entité associée. Veuillez "
 "contacter l'administrateur."
 
+#: incidents/email.py:75
+msgid "Cross-border"
+msgstr "Transfrontalier"
+
 #: incidents/filters.py:22
 msgid "Search"
 msgstr "Rechercher"

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -876,6 +876,10 @@ msgstr ""
 "Momenteel zijn aan de gebruikersaccount geen entiteiten gekoppeld. Neem "
 "contact op met de administrator."
 
+#: incidents/email.py:75
+msgid "Cross-border"
+msgstr "Grensoverschrijdend"
+
 #: incidents/filters.py:22
 msgid "Search"
 msgstr "Zoeken"

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -880,6 +880,10 @@ msgstr ""
 msgid "Search"
 msgstr "Zoeken"
 
+#: incidents/filters.py:66
+msgid "Cross-border impact"
+msgstr "Grensoverschrijdende impact"
+
 #: incidents/forms.py:246 incidents/forms.py:403
 msgid "Add details"
 msgstr "Voeg details toe"


### PR DESCRIPTION
Closes #846. Builds on #845, which introduces the annotation this reads.

**Reworked since first submission.** The original version prefixed the subject automatically. #846 offered a placeholder as an alternative, and #856 has since asked for dynamic status and comment fields in subjects and bodies — one shared mechanism beats two, so this is now the placeholder form.

## What it does

Adds `#CROSS_BORDER#` to `INCIDENT_EMAIL_VARIABLES`. It is substituted by the existing `replace_email_variables()`, so it works in a subject and in a content alike, and it renders a marker when the incident is reported as cross-border and an empty string otherwise.

The rationale is in the issue: an incident affecting two or more Member States is what triggers the Article 23(6) duty of the Article 8(3) single point of contact, the observer is emailed at every stage, and the message is the first thing that reaches that mailbox.

## It does nothing until an instance asks for it

Two conditions, both opt-in:

- the designated question must be named through the `ApplicationConfig` keys introduced in #845 (`cross_border_question_reference`, and optionally `cross_border_positive_answer`). Without it the annotation is `False` everywhere;
- the placeholder must appear in a template. **A template that does not carry it is unchanged**, which is the difference with the prefix this replaces: the deployment decides whether the marker appears and where.

## Semantics

The marker reflects the answer given in the **most recent** report answering the designated question, the same rule as the list badge in #845 and as `is_significative_impact`, which `save_answers()` overwrites on each submission. An incident that becomes cross-border in a later report starts being marked; one corrected to "no" stops.

## Two consequences of substituting into a subject

Both were found by sending real messages rather than by reading, and both are covered by tests.

- **The subject is taken in the instance language, so what is substituted into it now follows the same language.** Left to the ambient one, a translated placeholder renders in the language of whoever triggered the send, mixing two languages inside a single subject line. The content is unaffected: `render_to_string_multi_languages()` keeps rendering it once per configured language, and the marker follows each section.
- **A placeholder that renders empty leaves the spacing its template author wrote around it**, so `#CROSS_BORDER# Incident notification` produced a subject beginning with a space. Harmless in a body, visible in a mailbox, and routine now that a placeholder is empty by design half the time — runs of whitespace in the subject are collapsed after substitution.

## Changes

- `incidents/globals.py` — the new entry in `INCIDENT_EMAIL_VARIABLES`
- `incidents/helpers.py` — `is_cross_border_incident()`, the single-incident form of the annotation
- `incidents/email.py` — the placeholder branch, the subject language, the subject whitespace
- `incidents/tests/test_cross_border_email.py` — 11 tests
- `locale/{fr,de,nl}` — the marker

No migration, and no template change: unlike #845 this one needs nothing from `default-theme`, since a deployment edits its own email templates.

## Testing

The 11 tests cover the unconfigured case, a positive and a negative answer, an incident with no report, both directions of the "latest report wins" rule, the placeholder in the subject and in the content, a template that does not carry it, the instance language, the absence of a spacing artefact, and that recipients are unchanged.

Full suite passes, `ruff format --check` and `ruff check` are clean. Beyond unit tests, the change was exercised on a local instance seeded with nine incidents across five entities and four sectors: the subject carried the marker in each of the four configured languages on a cross-border incident, carried nothing on a non-cross-border one, and a template left without the placeholder produced exactly the subject it produced before.
