### PR TITLE
[NI][views] Let the incident export select on report status and report date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Unit tests for incident cleanup, log cleanup, workflow deadline notifications, and incident reminder scripts, helpers of governanceplatform
+- The incident export can restrict to reports in a given review status, and can apply its date window to the exported report rather than to the incident notification. A periodic regulatory filing needs both: it reports finished work, and a report filed after the period it belongs to otherwise falls outside every window. Both fields are optional and an export that leaves them alone is unchanged (#848)
 
 ### Changed
 

--- a/incidents/forms.py
+++ b/incidents/forms.py
@@ -19,7 +19,7 @@ from governanceplatform.helpers import (
 from governanceplatform.models import Regulation, Regulator, Sector, Service
 from governanceplatform.settings import TIME_ZONE
 
-from .globals import CONDITIONAL_QUESTION_TYPES, REGIONAL_AREA
+from .globals import CONDITIONAL_QUESTION_TYPES, EXPORT_DATE_BASIS, REGIONAL_AREA, WORKFLOW_REVIEW_STATUS
 from .helpers import get_workflow_categories
 from .models import (
     Answer,
@@ -1202,6 +1202,24 @@ class ExportIncidentsForm(forms.Form):
         queryset=Workflow.objects.none(),
         label=_("Report"),
         required=True,
+    )
+
+    review_status = forms.ChoiceField(
+        choices=[("", _("Any report status"))] + list(WORKFLOW_REVIEW_STATUS),
+        required=False,
+        label=_("Report status"),
+        help_text=_("Restrict the export to reports in this state. A periodic regulatory filing usually wants passed reports only."),
+    )
+
+    date_basis = forms.ChoiceField(
+        choices=EXPORT_DATE_BASIS,
+        required=False,
+        label=_("Apply the dates to"),
+        initial=EXPORT_DATE_BASIS[0][0],
+        help_text=_(
+            "The incident notification date is when the incident was first reported; the report date is when the exported "
+            "report was submitted. They fall in different periods when a report is filed after the period it belongs to."
+        ),
     )
 
     file_format = forms.ChoiceField(

--- a/incidents/globals.py
+++ b/incidents/globals.py
@@ -49,6 +49,14 @@ REVIEW_STATUS = [
     ("OUT", _("Submission overdue")),
 ]
 
+# Which date the export window applies to. The incident notification date and
+# the date of the exported report are independent: a report filed after the
+# period it belongs to falls in neither window when only the first is used.
+EXPORT_DATE_BASIS = [
+    ("notification", _("Incident notification date")),
+    ("report", _("Report date")),
+]
+
 WORKFLOW_REVIEW_STATUS = [
     ("UNDE", _("Unsubmitted")),
     ("DELIV", _("Under review")),

--- a/incidents/tests/test_export_incidents.py
+++ b/incidents/tests/test_export_incidents.py
@@ -1,0 +1,131 @@
+import csv
+import datetime
+import io
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from django.utils.translation import activate
+
+from governanceplatform.models import RegulatorUser
+from incidents.models import IncidentWorkflow, ReportTimeline, SectorRegulation, Workflow
+
+REGULATION_ID = 2
+SECTOR_REGULATION_ID = 1
+REPORT_ID = 1
+
+
+@pytest.fixture
+def exporting_client(otp_client, populate_incident_db):
+    """A regulator administrator allowed to export, with the second factor satisfied."""
+    user = next(u for u in populate_incident_db["users"] if u.email == "regadmin@reg1.lu")
+    RegulatorUser.objects.filter(user=user).update(
+        is_regulator_administrator=True,
+        can_export_incidents=True,
+    )
+    return otp_client(user)
+
+
+def submit_report(incident, submitted_at, review_status="PASS"):
+    """Submit the report the export is asked for."""
+    return IncidentWorkflow.objects.create(
+        incident=incident,
+        workflow=Workflow.objects.get(pk=REPORT_ID),
+        timestamp=submitted_at,
+        review_status=review_status,
+        report_timeline=ReportTimeline.objects.create(incident_detection_date=submitted_at),
+    )
+
+
+def notified_on(incident, notified_at):
+    incident.incident_notification_date = notified_at
+    incident.sector_regulation = SectorRegulation.objects.get(pk=SECTOR_REGULATION_ID)
+    incident.save()
+    return incident
+
+
+def export(client, from_date, to_date, **options):
+    payload = {
+        "regulation": REGULATION_ID,
+        "sectorregulation": SECTOR_REGULATION_ID,
+        "workflow": REPORT_ID,
+        "from_date": from_date.isoformat(),
+        "to_date": to_date.isoformat(),
+        "file_format": "csv",
+    }
+    payload.update(options)
+    return client.post(reverse("export_incidents"), payload)
+
+
+def references(response):
+    rows = csv.DictReader(io.StringIO(response.content.decode()))
+    return {row["Reference"] for row in rows}
+
+
+@pytest.mark.django_db
+def test_the_chosen_report_is_exported(exporting_client, populate_incident_db):
+    activate("en")
+    today = timezone.now().date()
+    incident = notified_on(populate_incident_db["incidents"][0], timezone.now())
+    submit_report(incident, timezone.now())
+
+    response = export(exporting_client, today - datetime.timedelta(days=1), today)
+
+    assert response.status_code == 200
+    assert references(response) == {incident.incident_id}
+
+
+@pytest.mark.django_db
+def test_a_report_awaiting_revision_is_exported_when_no_status_is_asked_for(exporting_client, populate_incident_db):
+    """Current behaviour, kept: the option has to be asked for."""
+    activate("en")
+    today = timezone.now().date()
+    incident = notified_on(populate_incident_db["incidents"][0], timezone.now())
+    submit_report(incident, timezone.now(), review_status="FAIL")
+
+    response = export(exporting_client, today - datetime.timedelta(days=1), today)
+
+    assert references(response) == {incident.incident_id}
+
+
+@pytest.mark.django_db
+def test_review_status_restricts_the_export(exporting_client, populate_incident_db):
+    """A periodic filing wants finished reports, not those sent back for revision."""
+    activate("en")
+    today = timezone.now().date()
+    passed, revised = populate_incident_db["incidents"][:2]
+    submit_report(notified_on(passed, timezone.now()), timezone.now(), review_status="PASS")
+    submit_report(notified_on(revised, timezone.now()), timezone.now(), review_status="FAIL")
+
+    response = export(exporting_client, today - datetime.timedelta(days=1), today, review_status="PASS")
+
+    assert references(response) == {passed.incident_id}
+
+
+@pytest.mark.django_db
+def test_dates_apply_to_the_incident_notification_by_default(exporting_client, populate_incident_db):
+    """An incident notified before the window stays out of it, however late its report is."""
+    activate("en")
+    today = timezone.now().date()
+    incident = notified_on(populate_incident_db["incidents"][0], timezone.now() - datetime.timedelta(days=100))
+    submit_report(incident, timezone.now())
+
+    response = export(exporting_client, today - datetime.timedelta(days=30), today)
+
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_dates_can_apply_to_the_report_instead(exporting_client, populate_incident_db):
+    """The report filed late lands in the period it was filed in, and only there."""
+    activate("en")
+    today = timezone.now().date()
+    late = notified_on(populate_incident_db["incidents"][0], timezone.now() - datetime.timedelta(days=100))
+    submit_report(late, timezone.now())
+    old = notified_on(populate_incident_db["incidents"][1], timezone.now() - datetime.timedelta(days=100))
+    submit_report(old, timezone.now() - datetime.timedelta(days=100))
+
+    response = export(exporting_client, today - datetime.timedelta(days=30), today, date_basis="report")
+
+    assert response.status_code == 200
+    assert references(response) == {late.incident_id}

--- a/incidents/views.py
+++ b/incidents/views.py
@@ -66,6 +66,7 @@ from .filters import IncidentFilter
 from .forms import ContactForm, ExportIncidentsForm, IncidentStatusForm, RegulatorIncidentWorkflowCommentForm, get_forms_list
 from .globals import (
     ALLOWED_SORT_FIELDS,
+    EXPORT_DATE_BASIS,
     REGIONAL_AREA,
     REPORT_STATUS_MAP,
     WORKFLOW_REVIEW_STATUS,
@@ -757,7 +758,21 @@ def export_incidents(request):
             from_date = form.cleaned_data["from_date"]
             to_date = form.cleaned_data["to_date"]
             file_format = form.cleaned_data["file_format"]
+            review_status = form.cleaned_data.get("review_status") or ""
+            date_basis = form.cleaned_data.get("date_basis") or EXPORT_DATE_BASIS[0][0]
             are_incidents = False
+
+            # When the window applies to the report, the incident's own
+            # notification date must not narrow the selection first: the two
+            # dates belong to different periods for a report filed late.
+            notification_window = (
+                {}
+                if date_basis == "report"
+                else {
+                    "incident_notification_date__date__gte": from_date,
+                    "incident_notification_date__date__lte": to_date,
+                }
+            )
 
             if user_in_group(user, "RegulatorAdmin"):
                 incidents = (
@@ -765,8 +780,7 @@ def export_incidents(request):
                         sector_regulation=sectorregulation,
                         sector_regulation__regulation=regulation,
                         sector_regulation__regulator__in=user.regulators.all(),
-                        incident_notification_date__date__gte=from_date,
-                        incident_notification_date__date__lte=to_date,
+                        **notification_window,
                     )
                     .prefetch_related(
                         "affected_sectors",
@@ -787,7 +801,7 @@ def export_incidents(request):
                     for i in all_incidents
                     if i.sector_regulation.regulation == regulation
                     and i.sector_regulation == sectorregulation
-                    and from_date <= i.incident_notification_date.date() <= to_date
+                    and (date_basis == "report" or from_date <= i.incident_notification_date.date() <= to_date)
                 ]
 
                 are_incidents = bool(incidents)
@@ -803,6 +817,12 @@ def export_incidents(request):
                 last_report = incident.get_latest_incident_workflow_by_workflow(workflow)
 
                 if last_report is None:
+                    continue
+
+                if review_status and last_report.review_status != review_status:
+                    continue
+
+                if date_basis == "report" and not (from_date <= last_report.timestamp.date() <= to_date):
                     continue
 
                 incident_data = {

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -887,6 +887,39 @@ msgstr ""
 "Dem Benutzerkonto sind derzeit keine Entitäten zugeordnet. Bitte wenden Sie "
 "sich an den Administrator."
 
+#: incidents/forms.py:1211
+msgid "Any report status"
+msgstr "Beliebiger Berichtstatus"
+
+#: incidents/forms.py:1214
+msgid ""
+"Restrict the export to reports in this state. A periodic regulatory "
+"filing usually wants passed reports only."
+msgstr ""
+"Beschränkt den Export auf Berichte in diesem Zustand. Eine periodische "
+"aufsichtsrechtliche Meldung berücksichtigt in der Regel nur bestandene "
+"Berichte."
+
+#: incidents/forms.py:1220
+msgid "Apply the dates to"
+msgstr "Datumsangaben beziehen sich auf"
+
+#: incidents/forms.py:1223
+msgid ""
+"The incident notification date is when the incident was first "
+"reported; the report date is when the exported report was submitted. "
+"They fall in different periods when a report is filed after the period "
+"it belongs to."
+msgstr ""
+"Das Meldedatum ist der Zeitpunkt der ersten Meldung des Vorfalls; das "
+"Berichtsdatum ist der Zeitpunkt der Einreichung des exportierten "
+"Berichts. Sie fallen in unterschiedliche Zeiträume, wenn ein Bericht "
+"nach dem Zeitraum eingereicht wird, zu dem er gehört."
+
+#: incidents/globals.py:57
+msgid "Report date"
+msgstr "Datum des Berichts"
+
 #: incidents/filters.py:22
 msgid "Search"
 msgstr "Suchen"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -884,6 +884,38 @@ msgstr ""
 "Le compte d'utilisateur n'a actuellement aucune entité associée. Veuillez "
 "contacter l'administrateur."
 
+#: incidents/forms.py:1211
+msgid "Any report status"
+msgstr "Tous les statuts de rapport"
+
+#: incidents/forms.py:1214
+msgid ""
+"Restrict the export to reports in this state. A periodic regulatory "
+"filing usually wants passed reports only."
+msgstr ""
+"Restreint l’export aux rapports dans cet état. Un dépôt réglementaire "
+"périodique ne retient en général que les rapports validés."
+
+#: incidents/forms.py:1220
+msgid "Apply the dates to"
+msgstr "Appliquer les dates à"
+
+#: incidents/forms.py:1223
+msgid ""
+"The incident notification date is when the incident was first "
+"reported; the report date is when the exported report was submitted. "
+"They fall in different periods when a report is filed after the period "
+"it belongs to."
+msgstr ""
+"La date de notification est celle du premier signalement de l’incident "
+"; la date du rapport est celle de la soumission du rapport exporté. "
+"Elles tombent dans des périodes différentes lorsqu’un rapport est "
+"déposé après la période à laquelle il se rattache."
+
+#: incidents/globals.py:57
+msgid "Report date"
+msgstr "Date du rapport"
+
 #: incidents/filters.py:22
 msgid "Search"
 msgstr "Rechercher"

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -876,6 +876,39 @@ msgstr ""
 "Momenteel zijn aan de gebruikersaccount geen entiteiten gekoppeld. Neem "
 "contact op met de administrator."
 
+#: incidents/forms.py:1211
+msgid "Any report status"
+msgstr "Elke rapportstatus"
+
+#: incidents/forms.py:1214
+msgid ""
+"Restrict the export to reports in this state. A periodic regulatory "
+"filing usually wants passed reports only."
+msgstr ""
+"Beperkt de export tot rapporten in deze staat. Een periodieke "
+"wettelijke indiening neemt doorgaans alleen goedgekeurde rapporten op."
+
+#: incidents/forms.py:1220
+msgid "Apply the dates to"
+msgstr "Datums toepassen op"
+
+#: incidents/forms.py:1223
+msgid ""
+"The incident notification date is when the incident was first "
+"reported; the report date is when the exported report was submitted. "
+"They fall in different periods when a report is filed after the period "
+"it belongs to."
+msgstr ""
+"De datum van incidentmelding is het moment waarop het incident voor "
+"het eerst is gemeld; de rapportdatum is het moment waarop het "
+"geëxporteerde rapport is ingediend. Ze vallen in verschillende "
+"periodes wanneer een rapport wordt ingediend na de periode waartoe het "
+"behoort."
+
+#: incidents/globals.py:57
+msgid "Report date"
+msgstr "Datum van het rapport"
+
 #: incidents/filters.py:22
 msgid "Search"
 msgstr "Zoeken"


### PR DESCRIPTION
Closes #848.

## What it does

Adds two optional fields to `ExportIncidentsForm`:

| Field | Effect |
|---|---|
| **Report status** | Keeps only the reports in the chosen review state. Empty means every state, as today. |
| **Apply the dates to** | Chooses whether the window bounds the incident notification date (default, unchanged) or the date of the exported report. |

The reasoning is in #848. No migration: `IncidentWorkflow.review_status` and `IncidentWorkflow.timestamp` already carry what is needed. An export that leaves both fields alone produces exactly the same file as before.

The template change is in a companion pull request: informed-governance-project/default-theme#11.

## Where it lands

The status filter and the report-date window are applied where `last_report` is already known, so `get_latest_incident_workflow_by_workflow()` is untouched. When the window applies to the report, the incident-level notification filter is not applied first — otherwise the two dates would narrow each other and the late-filed report could never appear. Both selection paths are covered: the regulator's queryset and the observer's Python list.

## Testing

`export_incidents` had **no test coverage at all**; these are the first, going through the view with the second factor via the existing `otp_client` fixture and parsing the CSV that comes back. Five cases: the chosen report is exported; a report awaiting revision is still exported when no status is asked for; a status restricts the export; the dates apply to the notification by default; and the dates can apply to the report instead.

Full suite passes. `ruff format --check` and `ruff check` are clean. French, German and Dutch translations included, checked by rendering the form in each language rather than by inspecting the catalogue. The status filter reuses the existing `Report status` string rather than introducing a near-duplicate.

Also exercised end to end on a local instance seeded with an incident notified in one quarter whose final report is validated in the next, and with a final report in `Revision required`. On a quarterly window, with both options set, the export contains the finished reports of the period and nothing else; with neither, it contains the report awaiting revision and misses the late-filed one.
